### PR TITLE
[codex] Add toasts to web app

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -3974,6 +3977,12 @@ packages:
 
   solid-js@1.9.10:
     resolution: {integrity: sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -8293,6 +8302,11 @@ snapshots:
       csstype: 3.2.3
       seroval: 1.3.2
       seroval-plugins: 1.3.3(seroval@1.3.2)
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,26 @@
+import { Toaster as Sonner } from 'sonner'
+import type { ToasterProps } from 'sonner'
+
+function Toaster({ ...props }: ToasterProps) {
+  return (
+    <Sonner
+      closeButton
+      richColors
+      theme="dark"
+      toastOptions={{
+        classNames: {
+          actionButton:
+            'bg-primary text-primary-foreground hover:bg-primary/90',
+          cancelButton:
+            'bg-muted text-muted-foreground hover:bg-muted/80',
+          description: 'text-muted-foreground',
+          toast:
+            'border-white/10 bg-[color:var(--color-elevated)] text-foreground shadow-[0_24px_80px_-24px_rgba(0,0,0,0.85)]',
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/src/features/trading/components/order-entry-card.tsx
+++ b/src/features/trading/components/order-entry-card.tsx
@@ -1,11 +1,10 @@
+import { DURATION_OPTIONS } from '../constants'
+import { formatUiAmount } from '../lib/format'
+import type { OrderSide } from '../constants'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
-import { Alert } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
-import type { OrderSide } from '../constants'
-import { DURATION_OPTIONS } from '../constants'
-import { formatUiAmount } from '../lib/format'
 
 export function OrderEntryCard({
   amountInput,
@@ -27,7 +26,6 @@ export function OrderEntryCard({
   selectedPercent,
   side,
   statusLabel,
-  validationError,
 }: {
   amountInput: string
   amountTokenTicker: string
@@ -48,7 +46,6 @@ export function OrderEntryCard({
   selectedPercent: number
   side: OrderSide
   statusLabel: string
-  validationError: string | null
 }) {
   return (
     <Card className="border-white/10 bg-black/20">
@@ -181,12 +178,6 @@ export function OrderEntryCard({
             ))}
           </div>
         </div>
-
-        {validationError ? (
-          <Alert className="border-destructive/30 bg-destructive/10 text-destructive">
-            {validationError}
-          </Alert>
-        ) : null}
 
         <Button
           className="h-12 w-full rounded-2xl text-base"

--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -1,6 +1,7 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useWalletConnection, useWalletSession } from '@solana/react-hooks'
-import { ArrowUpRight, RefreshCcw } from 'lucide-react'
+import { RefreshCcw } from 'lucide-react'
+import { toast } from 'sonner'
 import {
   CHART_TIMEFRAMES,
   DEFAULT_MARKET_UPDATES_LIMIT,
@@ -43,7 +44,6 @@ import type { TradePositionRecord } from '../domain/models'
 import { endpoint } from '@/integrations/solana'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Alert } from '@/components/ui/alert'
 
 const DEFAULT_VISIBLE_BARS_BY_TIMEFRAME: Record<ChartTimeframe, number> = {
   '1m': 120,
@@ -78,7 +78,6 @@ export function TradingDashboard() {
   const [crosshairData, setCrosshairData] = useState<ChartCrosshairData | null>(
     null,
   )
-  const [validationError, setValidationError] = useState<string | null>(null)
 
   const submitOrder = useSubmitOrder()
   const closePosition = useClosePosition()
@@ -186,6 +185,64 @@ export function TradingDashboard() {
             ? 'Submit buy order'
             : 'Submit sell order'
 
+  useEffect(() => {
+    const signature = submitOrder.signature
+    if (submitOrder.status !== 'success' || !signature) return
+
+    toast.success('Order submitted', {
+      action: {
+        label: 'View',
+        onClick: () => {
+          window.open(
+            formatExplorerTransactionUrl(signature, endpoint),
+            '_blank',
+            'noopener,noreferrer',
+          )
+        },
+      },
+      description: 'The transaction was confirmed.',
+      id: `submit-order-success-${signature}`,
+    })
+  }, [submitOrder.signature, submitOrder.status])
+
+  useEffect(() => {
+    if (!submitOrder.error) return
+
+    toast.error('Order failed', {
+      description: submitOrder.error,
+      id: 'submit-order-error',
+    })
+  }, [submitOrder.error])
+
+  useEffect(() => {
+    const signature = closePosition.signature
+    if (closePosition.status !== 'success' || !signature) return
+
+    toast.success('Position closed', {
+      action: {
+        label: 'View',
+        onClick: () => {
+          window.open(
+            formatExplorerTransactionUrl(signature, endpoint),
+            '_blank',
+            'noopener,noreferrer',
+          )
+        },
+      },
+      description: 'The close transaction was confirmed.',
+      id: `close-position-success-${signature}`,
+    })
+  }, [closePosition.signature, closePosition.status])
+
+  useEffect(() => {
+    if (!closePosition.error) return
+
+    toast.error('Close failed', {
+      description: closePosition.error,
+      id: 'close-position-error',
+    })
+  }, [closePosition.error])
+
   const refreshBalances = async () => {
     await Promise.allSettled([baseBalance.refresh(), quoteBalance.refresh()])
   }
@@ -206,26 +263,31 @@ export function TradingDashboard() {
 
     const nextAmountAtoms = atomsFromPercent(availableAtoms, percent)
     setAmountInput(formatAtomsToInput(nextAmountAtoms, amountDecimals))
-    setValidationError(null)
   }
 
   const handleSubmit = async () => {
     if (!marketAddress) {
-      setValidationError('Market address is still loading.')
+      toast.error('Order not ready', {
+        description: 'Market address is still loading.',
+        id: 'order-validation',
+      })
       return
     }
     if (!amountAtoms || amountAtoms <= 0n) {
-      setValidationError(`Enter a valid ${amountTokenTicker} amount.`)
+      toast.error('Order not ready', {
+        description: `Enter a valid ${amountTokenTicker} amount.`,
+        id: 'order-validation',
+      })
       return
     }
     if (amountAtoms > availableAtoms) {
-      setValidationError(
-        `Amount exceeds available ${amountTokenTicker} balance.`,
-      )
+      toast.error('Order not ready', {
+        description: `Amount exceeds available ${amountTokenTicker} balance.`,
+        id: 'order-validation',
+      })
       return
     }
 
-    setValidationError(null)
     const durationSlots = durationToSlots(durationSeconds)
     const success = await submitOrder.submitOrder({
       amount: amountAtoms,
@@ -243,15 +305,6 @@ export function TradingDashboard() {
     }
   }
 
-  const topAlert = validationError ?? submitOrder.error ?? closePosition.error
-  const topAlertVariant =
-    submitOrder.status === 'success' || closePosition.status === 'success'
-      ? 'success'
-      : topAlert
-        ? 'error'
-        : null
-  const txSignature = submitOrder.signature ?? closePosition.signature
-
   return (
     <div className="relative min-h-screen bg-[color:var(--color-page-bg)] text-foreground">
       <div className="relative mx-auto max-w-[1440px] px-4 pb-12 pt-5 sm:px-6 lg:px-8">
@@ -263,31 +316,6 @@ export function TradingDashboard() {
             {formatDashboardPrice(displayPrice)}
           </span>
         </div>
-
-        {topAlert ? (
-          <Alert
-            className={`mb-6 ${
-              topAlertVariant === 'success'
-                ? 'border-emerald-400/30 bg-emerald-400/10 text-emerald-100'
-                : 'border-destructive/30 bg-destructive/10 text-destructive'
-            }`}
-          >
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <span>{topAlert}</span>
-              {txSignature ? (
-                <a
-                  className="inline-flex items-center gap-1 font-medium underline underline-offset-4"
-                  href={formatExplorerTransactionUrl(txSignature, endpoint)}
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  View transaction
-                  <ArrowUpRight className="size-4" />
-                </a>
-              ) : null}
-            </div>
-          </Alert>
-        ) : null}
 
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(22rem,0.95fr)]">
           <div className="space-y-6 xl:col-start-2 xl:row-start-1">
@@ -304,7 +332,6 @@ export function TradingDashboard() {
               isConnected={walletConnection.connected}
               onAmountChange={(value) => {
                 setAmountInput(sanitizeAmountInput(value))
-                setValidationError(null)
               }}
               onDurationChange={setDurationSeconds}
               onMaxClick={() => handleSliderChange(100)}
@@ -312,7 +339,6 @@ export function TradingDashboard() {
               onSideChange={(nextSide) => {
                 setSide(nextSide)
                 setAmountInput('')
-                setValidationError(null)
               }}
               onSliderChange={handleSliderChange}
               onSubmit={() => void handleSubmit()}
@@ -320,7 +346,6 @@ export function TradingDashboard() {
               selectedPercent={sliderValue}
               side={side}
               statusLabel={submitStatusLabel}
-              validationError={validationError}
             />
           </div>
 

--- a/src/features/trading/components/wallet-connection-button.tsx
+++ b/src/features/trading/components/wallet-connection-button.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useWalletConnection } from '@solana/react-hooks'
+import { toast } from 'sonner'
 import {
   Check,
   ChevronDown,
@@ -8,11 +9,12 @@ import {
   LogOut,
   Wallet,
 } from 'lucide-react'
+import { useReclaimRent } from '../hooks/use-reclaim-rent'
+import { formatExplorerTransactionUrl, shortenAddress } from '../lib/format'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
-import { shortenAddress } from '../lib/format'
-import { useReclaimRent } from '../hooks/use-reclaim-rent'
+import { endpoint } from '@/integrations/solana'
 
 export function WalletConnectionButton() {
   const {
@@ -52,6 +54,46 @@ export function WalletConnectionButton() {
     reclaimRent.clearFeedback()
   }, [open, reclaimRent.clearFeedback])
 
+  useEffect(() => {
+    if (status !== 'error') return
+
+    toast.error('Wallet connection failed', {
+      description: 'Try another connector.',
+      id: 'wallet-connection-error',
+    })
+  }, [status])
+
+  useEffect(() => {
+    const signature = reclaimRent.signature
+    if (reclaimRent.status !== 'success' || !signature) return
+
+    toast.success('Rent reclaimed', {
+      action: {
+        label: 'View',
+        onClick: () => {
+          window.open(
+            formatExplorerTransactionUrl(signature, endpoint),
+            '_blank',
+            'noopener,noreferrer',
+          )
+        },
+      },
+      description: `Closed ${reclaimRent.reclaimedCount} rent account${
+        reclaimRent.reclaimedCount === 1 ? '' : 's'
+      }.`,
+      id: `reclaim-rent-success-${signature}`,
+    })
+  }, [reclaimRent.reclaimedCount, reclaimRent.signature, reclaimRent.status])
+
+  useEffect(() => {
+    if (!reclaimRent.error) return
+
+    toast.error('Rent reclaim failed', {
+      description: reclaimRent.error,
+      id: 'reclaim-rent-error',
+    })
+  }, [reclaimRent.error])
+
   if (!isReady) {
     return (
       <Button
@@ -67,8 +109,7 @@ export function WalletConnectionButton() {
   const address = wallet?.account.address.toString() ?? null
 
   const handleCopyAddress = async () => {
-    if (!address || typeof navigator === 'undefined' || !navigator.clipboard)
-      return
+    if (!address) return
 
     await navigator.clipboard.writeText(address)
     setCopied(true)
@@ -154,17 +195,6 @@ export function WalletConnectionButton() {
                   Disconnect
                   <LogOut className="size-4" />
                 </Button>
-                {reclaimRent.status === 'success' ? (
-                  <p className="text-sm text-emerald-300">
-                    Reclaimed rent from {reclaimRent.reclaimedCount} account
-                    {reclaimRent.reclaimedCount === 1 ? '' : 's'}.
-                  </p>
-                ) : null}
-                {reclaimRent.error ? (
-                  <p className="text-sm text-destructive">
-                    {reclaimRent.error}
-                  </p>
-                ) : null}
               </>
             ) : (
               <>
@@ -198,11 +228,6 @@ export function WalletConnectionButton() {
               </>
             )}
 
-            {status === 'error' ? (
-              <p className="text-sm text-destructive">
-                Wallet connection failed. Try another connector.
-              </p>
-            ) : null}
           </CardContent>
         </Card>
       ) : null}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import TanStackQueryDevtools from '../integrations/tanstack-query/devtools'
 import { SolanaProvider } from '../integrations/solana'
 import { Navbar } from '../components/navbar'
 import { RiskDisclaimerDialog } from '../components/risk-disclaimer-dialog'
+import { Toaster } from '../components/ui/sonner'
 import { WalletConnectionButton } from '../features/trading/components/wallet-connection-button'
 
 import appCss from '../styles.css?url'
@@ -66,7 +67,10 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        <SolanaProvider>{children}</SolanaProvider>
+        <SolanaProvider>
+          {children}
+          <Toaster position="top-right" />
+        </SolanaProvider>
         <TanStackDevtools
           config={{
             position: 'bottom-right',


### PR DESCRIPTION
## Summary

Implements NAC-9 by moving meaningful web app feedback from inline text/alerts into Sonner toasts.

- Adds the `sonner` dependency and a shadcn-style `Toaster` wrapper.
- Mounts the toaster at the root app layout.
- Replaces order validation, order submit, and close-position success/error messages with toasts.
- Replaces wallet connection and reclaim-rent feedback text with toasts.
- Adds transaction success toast actions that open the matching Solana Explorer URL.

## Validation

- `corepack pnpm test` passed: 9 files, 34 tests.
- `corepack pnpm exec eslint src/components/ui/sonner.tsx src/features/trading/components/order-entry-card.tsx src/features/trading/components/trading-dashboard.tsx src/features/trading/components/wallet-connection-button.tsx src/routes/__root.tsx` passed.
- `corepack pnpm build` passed.

Note: full `pnpm lint` still fails on existing repo-wide lint issues unrelated to this change.