### PR TITLE
[codex] Show reclaimed SOL in rent toast

### DIFF
--- a/src/features/trading/api/rent-accounts.ts
+++ b/src/features/trading/api/rent-accounts.ts
@@ -13,7 +13,7 @@ import { encodeBase58 } from '../lib/base58'
 import type { TwobRpcClient } from './twob-client'
 
 type ProgramAccountResponse = {
-  account: { data: [string, string] }
+  account: { data: [string, string]; lamports: bigint | number | string }
   pubkey: Address
 }
 
@@ -27,14 +27,20 @@ function asProgramAccounts(response: ProgramAccountsResponse) {
   return Array.isArray(response) ? response : response.value
 }
 
+function toLamports(value: bigint | number | string) {
+  return typeof value === 'bigint' ? value : BigInt(value)
+}
+
 export type OwnedPricesAccount = {
   address: Address
   data: Prices
+  lamports: bigint
 }
 
 export type OwnedExitsAccount = {
   address: Address
   data: Exits
+  lamports: bigint
 }
 
 export async function fetchOwnedPricesAccounts(
@@ -71,6 +77,7 @@ export async function fetchOwnedPricesAccounts(
     .map(({ account, pubkey }) => ({
       address: pubkey,
       data: decoder.decode(decodeBase64(account.data[0])),
+      lamports: toLamports(account.lamports),
     }))
     .sort((left, right) => {
       if (left.data.index === right.data.index) return 0
@@ -112,6 +119,7 @@ export async function fetchOwnedExitsAccounts(
     .map(({ account, pubkey }) => ({
       address: pubkey,
       data: decoder.decode(decodeBase64(account.data[0])),
+      lamports: toLamports(account.lamports),
     }))
     .sort((left, right) => {
       if (left.data.index === right.data.index) return 0

--- a/src/features/trading/api/twob-client.ts
+++ b/src/features/trading/api/twob-client.ts
@@ -743,12 +743,14 @@ export async function sendReclaimRent({
     (account) => ({
       address: account.address,
       index: account.data.index,
+      lamports: account.lamports,
     }),
   )
   const pricesAccounts: PricesRentAccount[] = ownedPricesAccounts.map(
     (account) => ({
       address: account.address,
       index: account.data.index,
+      lamports: account.lamports,
       openPositions: account.data.openPositions,
     }),
   )
@@ -788,6 +790,10 @@ export async function sendReclaimRent({
   if (closeableAccounts.length === 0) {
     throw new Error('No reclaimable rent accounts available.')
   }
+  const reclaimedLamports = closeableAccounts.reduce(
+    (sum, account) => sum + account.lamports,
+    0n,
+  )
   const [
     bookkeepingAddress,
     currentExits,
@@ -866,7 +872,7 @@ export async function sendReclaimRent({
   await waitForConfirmedSignature(client.runtime.rpc, serializedSignature)
 
   return {
-    closedAccounts: closeableAccounts.length,
+    reclaimedLamports,
     signature: serializedSignature,
   }
 }

--- a/src/features/trading/components/wallet-connection-button.tsx
+++ b/src/features/trading/components/wallet-connection-button.tsx
@@ -10,7 +10,11 @@ import {
   Wallet,
 } from 'lucide-react'
 import { useReclaimRent } from '../hooks/use-reclaim-rent'
-import { formatExplorerTransactionUrl, shortenAddress } from '../lib/format'
+import {
+  formatAtoms,
+  formatExplorerTransactionUrl,
+  shortenAddress,
+} from '../lib/format'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
@@ -78,12 +82,13 @@ export function WalletConnectionButton() {
           )
         },
       },
-      description: `Closed ${reclaimRent.reclaimedCount} rent account${
-        reclaimRent.reclaimedCount === 1 ? '' : 's'
-      }.`,
+      description: `Reclaimed ${formatAtoms(
+        reclaimRent.reclaimedLamports,
+        9,
+      )} SOL.`,
       id: `reclaim-rent-success-${signature}`,
     })
-  }, [reclaimRent.reclaimedCount, reclaimRent.signature, reclaimRent.status])
+  }, [reclaimRent.reclaimedLamports, reclaimRent.signature, reclaimRent.status])
 
   useEffect(() => {
     if (!reclaimRent.error) return

--- a/src/features/trading/hooks/use-reclaim-rent.ts
+++ b/src/features/trading/hooks/use-reclaim-rent.ts
@@ -43,7 +43,7 @@ export function useReclaimRent(enabled: boolean) {
   const [status, setStatus] = useState<ReclaimRentStatus>('idle')
   const [error, setError] = useState<string | null>(null)
   const [signature, setSignature] = useState<string | null>(null)
-  const [reclaimedCount, setReclaimedCount] = useState(0)
+  const [reclaimedLamports, setReclaimedLamports] = useState(0n)
 
   const exitsQuery = useQuery({
     ...tradingQueries.ownedExitsAccounts({ authority: ownerAddress, client }),
@@ -93,6 +93,7 @@ export function useReclaimRent(enabled: boolean) {
       (exitsQuery.data ?? []).map((account) => ({
         address: account.address,
         index: account.data.index,
+        lamports: account.lamports,
       })),
     [exitsQuery.data],
   )
@@ -101,6 +102,7 @@ export function useReclaimRent(enabled: boolean) {
       (pricesQuery.data ?? []).map((account) => ({
         address: account.address,
         index: account.data.index,
+        lamports: account.lamports,
         openPositions: account.data.openPositions,
       })),
     [pricesQuery.data],
@@ -153,7 +155,7 @@ export function useReclaimRent(enabled: boolean) {
     setStatus('building')
     setError(null)
     setSignature(null)
-    setReclaimedCount(0)
+    setReclaimedLamports(0n)
 
     try {
       setStatus('submitting')
@@ -167,7 +169,7 @@ export function useReclaimRent(enabled: boolean) {
       })
 
       setStatus('success')
-      setReclaimedCount(result.closedAccounts)
+      setReclaimedLamports(result.reclaimedLamports)
       setSignature(result.signature)
 
       const connectedAddress = session.account.address.toString()
@@ -195,14 +197,14 @@ export function useReclaimRent(enabled: boolean) {
     setStatus('idle')
     setError(null)
     setSignature(null)
-    setReclaimedCount(0)
+    setReclaimedLamports(0n)
   }, [sendTransaction])
 
   const clearFeedback = useCallback(() => {
     setStatus('idle')
     setError(null)
     setSignature(null)
-    setReclaimedCount(0)
+    setReclaimedLamports(0n)
   }, [])
 
   return {
@@ -216,7 +218,7 @@ export function useReclaimRent(enabled: boolean) {
         runtimeContextQuery.isPending),
     isReclaiming: status === 'building' || status === 'submitting',
     reclaimRent,
-    reclaimedCount,
+    reclaimedLamports,
     reset,
     signature,
     status,

--- a/src/features/trading/lib/rent.test.ts
+++ b/src/features/trading/lib/rent.test.ts
@@ -60,18 +60,24 @@ describe('rent eligibility', () => {
       currentSlot: 10_000n,
       endSlotInterval: 5n,
       exitsAccounts: [
-        { address: asAddress('11111111111111111111111111111111'), index: 0n },
+        {
+          address: asAddress('11111111111111111111111111111111'),
+          index: 0n,
+          lamports: 1_000_000n,
+        },
       ],
       maxAccounts: 1,
       pricesAccounts: [
         {
           address: asAddress('SysvarC1ock11111111111111111111111111111111'),
           index: 0n,
+          lamports: 2_000_000n,
           openPositions: 0n,
         },
       ],
     })
 
     expect(accounts).toHaveLength(1)
+    expect(accounts[0]?.lamports).toBe(1_000_000n)
   })
 })

--- a/src/features/trading/lib/rent.ts
+++ b/src/features/trading/lib/rent.ts
@@ -7,11 +7,13 @@ import {
 export type ExitsRentAccount = {
   address: Address
   index: bigint
+  lamports: bigint
 }
 
 export type PricesRentAccount = {
   address: Address
   index: bigint
+  lamports: bigint
   openPositions: bigint
 }
 
@@ -20,11 +22,13 @@ export type RentAccountToClose =
       address: Address
       index: bigint
       kind: 'exits'
+      lamports: bigint
     }
   | {
       address: Address
       index: bigint
       kind: 'prices'
+      lamports: bigint
       openPositions: bigint
     }
 
@@ -93,6 +97,7 @@ export function collectCloseableRentAccounts({
       address: account.address,
       index: account.index,
       kind: 'exits' as const,
+      lamports: account.lamports,
     }))
 
   const closeablePrices: RentAccountToClose[] = pricesAccounts
@@ -108,6 +113,7 @@ export function collectCloseableRentAccounts({
       address: account.address,
       index: account.index,
       kind: 'prices' as const,
+      lamports: account.lamports,
       openPositions: account.openPositions,
     }))
 


### PR DESCRIPTION
## Summary

Implements NAC-10 by showing the amount of SOL reclaimed in the rent reclaim toast instead of the number of closed accounts.

- Carries rent account lamports from `getProgramAccounts` into owned prices/exits account models.
- Preserves lamports through rent eligibility filtering.
- Returns the summed reclaimed lamports from the reclaim transaction helper.
- Updates the wallet reclaim toast to display the reclaimed amount in SOL.

## Validation

- Pulled latest `main` before branching.
- `corepack pnpm test` passed: 9 files, 34 tests.
- `corepack pnpm build` passed.
- `git diff --check` passed.

Note: targeted ESLint on the touched rent/client files still fails on existing import-order and array-type style debt in those files; the new TypeScript path is covered by the build.