### PR TITLE
refactor: tokenize new color scheme

### DIFF
--- a/src/components/risk-disclaimer-dialog.tsx
+++ b/src/components/risk-disclaimer-dialog.tsx
@@ -31,7 +31,7 @@ export function RiskDisclaimerDialog() {
     <Dialog open={open}>
       <DialogContent showCloseButton={false}>
         <DialogHeader>
-          <div className="flex items-center gap-2 text-amber-400">
+          <div className="flex items-center gap-2 text-warning">
             <AlertTriangle className="size-5" />
             <DialogTitle>Experimental Protocol</DialogTitle>
           </div>

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -8,8 +8,8 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: 'border-border/70 bg-secondary/80 text-secondary-foreground',
-        positive: 'border-emerald-400/30 bg-emerald-400/12 text-emerald-200',
-        negative: 'border-rose-400/30 bg-rose-400/12 text-rose-200',
+        positive: 'border-positive/30 bg-positive/12 text-positive-foreground',
+        negative: 'border-negative/30 bg-negative/12 text-negative-foreground',
         muted: 'border-border/50 bg-background/40 text-muted-foreground',
         accent:
           'border-[color:var(--color-accent-strong)]/35 bg-[color:var(--color-accent-strong)]/10 text-[color:var(--color-accent-warm)]',

--- a/src/features/trading/components/active-position-card.tsx
+++ b/src/features/trading/components/active-position-card.tsx
@@ -103,7 +103,7 @@ export function ActivePositionCard({
 
         <Progress
           className="h-2.5 bg-white/8"
-          indicatorClassName="bg-[linear-gradient(90deg,var(--color-accent-strong),#f0586a)]"
+          indicatorClassName="bg-[linear-gradient(90deg,var(--color-accent-strong),var(--color-accent-strong-soft))]"
           value={metrics.progressPercent}
         />
 

--- a/src/features/trading/components/active-position-card.tsx
+++ b/src/features/trading/components/active-position-card.tsx
@@ -103,7 +103,7 @@ export function ActivePositionCard({
 
         <Progress
           className="h-2.5 bg-white/8"
-          indicatorClassName="bg-[linear-gradient(90deg,var(--color-accent-strong),#7be6c1)]"
+          indicatorClassName="bg-[linear-gradient(90deg,var(--color-accent-strong),#f0586a)]"
           value={metrics.progressPercent}
         />
 
@@ -142,7 +142,7 @@ export function ActivePositionCard({
           />
         </div>
         <Button
-          className="w-full rounded-xl bg-rose-500/85 text-white hover:bg-rose-500"
+          className="w-full rounded-xl bg-destructive/85 text-white hover:bg-destructive"
           disabled={isClosing}
           onClick={() => onClose(position.address)}
         >

--- a/src/features/trading/components/closed-positions-list.tsx
+++ b/src/features/trading/components/closed-positions-list.tsx
@@ -438,9 +438,9 @@ const ClosedPositionRow = memo(function ClosedPositionRow({
       {hasChart ? (
         <div className="mt-4">
           <MiniPriceChart
-            averageClassName="stroke-emerald-300/70"
+            averageClassName="stroke-[#1fd79a]/55"
             averagePrice={summary.averageFillPrice}
-            lineClassName="stroke-[color:var(--color-accent-strong)]"
+            lineClassName="stroke-[#1fd79a]"
             points={chartPoints}
           />
         </div>

--- a/src/features/trading/components/closed-positions-list.tsx
+++ b/src/features/trading/components/closed-positions-list.tsx
@@ -438,9 +438,9 @@ const ClosedPositionRow = memo(function ClosedPositionRow({
       {hasChart ? (
         <div className="mt-4">
           <MiniPriceChart
-            averageClassName="stroke-[#1fd79a]/55"
+            averageClassName="stroke-positive/55"
             averagePrice={summary.averageFillPrice}
-            lineClassName="stroke-[#1fd79a]"
+            lineClassName="stroke-positive"
             points={chartPoints}
           />
         </div>

--- a/src/features/trading/components/market-price-chart.tsx
+++ b/src/features/trading/components/market-price-chart.tsx
@@ -225,7 +225,7 @@ export function MarketPriceChart({
   const histogramData = useMemo(
     () =>
       chartData.map<HistogramData<UTCTimestamp>>((candle) => ({
-        color: candle.close >= candle.open ? '#43c29a55' : '#f86f7055',
+        color: candle.close >= candle.open ? '#1fd79a55' : '#d4243a55',
         time: candle.time as UTCTimestamp,
         value: candle.volume,
       })),
@@ -384,12 +384,12 @@ export function MarketPriceChart({
     })
 
     const candleSeries = chart.addSeries(CandlestickSeries, {
-      borderDownColor: '#f86f70',
-      borderUpColor: '#43c29a',
-      downColor: '#f86f70',
-      wickDownColor: '#f86f70',
-      wickUpColor: '#43c29a',
-      upColor: '#43c29a',
+      borderDownColor: '#d4243a',
+      borderUpColor: '#1fd79a',
+      downColor: '#d4243a',
+      wickDownColor: '#d4243a',
+      wickUpColor: '#1fd79a',
+      upColor: '#1fd79a',
     })
 
     const volumeSeries = chart.addSeries(HistogramSeries, {

--- a/src/features/trading/components/market-price-chart.tsx
+++ b/src/features/trading/components/market-price-chart.tsx
@@ -209,6 +209,16 @@ export function MarketPriceChart({
   const chartRef = useRef<IChartApi | null>(null)
   const candleSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
   const volumeSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null)
+  const seriesColors = useMemo(() => {
+    if (typeof document === 'undefined') {
+      return { positive: '#1fd79a', negative: '#d4243a' }
+    }
+    const root = getComputedStyle(document.documentElement)
+    return {
+      positive: root.getPropertyValue('--color-positive').trim() || '#1fd79a',
+      negative: root.getPropertyValue('--color-negative').trim() || '#d4243a',
+    }
+  }, [])
   const previousDataLengthRef = useRef(0)
   const previousFirstTimeRef = useRef<number | null>(null)
   const previousLastTimeRef = useRef<number | null>(null)
@@ -225,11 +235,14 @@ export function MarketPriceChart({
   const histogramData = useMemo(
     () =>
       chartData.map<HistogramData<UTCTimestamp>>((candle) => ({
-        color: candle.close >= candle.open ? '#1fd79a55' : '#d4243a55',
+        color:
+          candle.close >= candle.open
+            ? `${seriesColors.positive}55`
+            : `${seriesColors.negative}55`,
         time: candle.time as UTCTimestamp,
         value: candle.volume,
       })),
-    [chartData],
+    [chartData, seriesColors.positive, seriesColors.negative],
   )
   const candleData = useMemo(
     () =>
@@ -384,12 +397,12 @@ export function MarketPriceChart({
     })
 
     const candleSeries = chart.addSeries(CandlestickSeries, {
-      borderDownColor: '#d4243a',
-      borderUpColor: '#1fd79a',
-      downColor: '#d4243a',
-      wickDownColor: '#d4243a',
-      wickUpColor: '#1fd79a',
-      upColor: '#1fd79a',
+      borderDownColor: seriesColors.negative,
+      borderUpColor: seriesColors.positive,
+      downColor: seriesColors.negative,
+      wickDownColor: seriesColors.negative,
+      wickUpColor: seriesColors.positive,
+      upColor: seriesColors.positive,
     })
 
     const volumeSeries = chart.addSeries(HistogramSeries, {
@@ -532,7 +545,7 @@ export function MarketPriceChart({
         wheelGestureTimeoutRef.current = null
       }
     }
-  }, [height])
+  }, [height, seriesColors])
 
   useEffect(() => {
     if (

--- a/src/features/trading/components/mini-price-chart.tsx
+++ b/src/features/trading/components/mini-price-chart.tsx
@@ -69,9 +69,9 @@ function LegendSwatch({
 
 export function MiniPriceChart({
   averagePrice,
-  lineClassName = 'stroke-[color:var(--color-accent-strong)]',
+  lineClassName = 'stroke-[#1fd79a]',
   points,
-  averageClassName = 'stroke-emerald-300/70',
+  averageClassName = 'stroke-[#1fd79a]/55',
 }: {
   averagePrice: number | null
   averageClassName?: string

--- a/src/features/trading/components/mini-price-chart.tsx
+++ b/src/features/trading/components/mini-price-chart.tsx
@@ -69,9 +69,9 @@ function LegendSwatch({
 
 export function MiniPriceChart({
   averagePrice,
-  lineClassName = 'stroke-[#1fd79a]',
+  lineClassName = 'stroke-positive',
   points,
-  averageClassName = 'stroke-[#1fd79a]/55',
+  averageClassName = 'stroke-positive/55',
 }: {
   averagePrice: number | null
   averageClassName?: string

--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -399,7 +399,7 @@ export function TradingDashboard() {
         </div>
 
         {lowSubmitNativeSolWarning ? (
-          <Alert className="mb-5 flex items-start gap-3 border-amber-400/35 bg-amber-500/10 text-amber-100">
+          <Alert className="mb-5 flex items-start gap-3 border-warning/35 bg-warning/10 text-warning-foreground">
             <AlertTriangle className="mt-0.5 size-4 shrink-0" />
             <span>{lowSubmitNativeSolWarning}</span>
           </Alert>

--- a/src/features/trading/components/wallet-connection-button.tsx
+++ b/src/features/trading/components/wallet-connection-button.tsx
@@ -226,7 +226,7 @@ export function WalletConnectionButton() {
                       <HandCoins className="size-4" />
                     </Button>
                     {reclaimRentNativeSolWarning ? (
-                      <div className="flex items-start gap-2 rounded-xl border border-amber-400/35 bg-amber-500/10 px-3 py-2 text-xs leading-5 text-amber-100">
+                      <div className="flex items-start gap-2 rounded-xl border border-warning/35 bg-warning/10 px-3 py-2 text-xs leading-5 text-warning-foreground">
                         <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
                         <span>{reclaimRentNativeSolWarning}</span>
                       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -42,7 +42,14 @@
   --sidebar-border: oklch(0.35 0.03 246);
   --sidebar-ring: #d4243a;
   --color-accent-strong: #d4243a;
+  --color-accent-strong-soft: #f0586a;
   --color-accent-warm: #f6c465;
+  --color-positive: #1fd79a;
+  --color-positive-foreground: #a7f3d0;
+  --color-negative: var(--color-accent-strong);
+  --color-negative-foreground: #fecdd3;
+  --color-warning: var(--color-accent-warm);
+  --color-warning-foreground: #fef3c7;
 }
 
 @theme inline {
@@ -87,7 +94,14 @@
   --color-page-bg: var(--page-bg);
   --color-elevated: var(--elevated);
   --color-accent-strong: var(--color-accent-strong);
+  --color-accent-strong-soft: var(--color-accent-strong-soft);
   --color-accent-warm: var(--color-accent-warm);
+  --color-positive: var(--color-positive);
+  --color-positive-foreground: var(--color-positive-foreground);
+  --color-negative: var(--color-negative);
+  --color-negative-foreground: var(--color-negative-foreground);
+  --color-warning: var(--color-warning);
+  --color-warning-foreground: var(--color-warning-foreground);
 }
 
 @layer base {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
 @import 'tailwindcss';
 
 @import 'tw-animate-css';
@@ -7,27 +7,27 @@
 
 :root {
   --page-bg: #07111f;
-  --elevated: #0d1a2d;
+  --elevated: #0f1a2c;
   --background: oklch(0.16 0.03 248);
   --foreground: oklch(0.95 0.01 92);
   --card: oklch(0.22 0.03 248 / 0.92);
   --card-foreground: oklch(0.95 0.01 92);
   --popover: oklch(0.22 0.03 248 / 0.96);
   --popover-foreground: oklch(0.95 0.01 92);
-  --primary: oklch(0.71 0.15 174);
-  --primary-foreground: oklch(0.16 0.03 248);
+  --primary: #d4243a;
+  --primary-foreground: oklch(0.98 0.01 90);
   --secondary: oklch(0.28 0.03 244);
   --secondary-foreground: oklch(0.94 0.01 92);
   --muted: oklch(0.25 0.02 245);
   --muted-foreground: oklch(0.77 0.02 86);
   --accent: oklch(0.82 0.11 80);
   --accent-foreground: oklch(0.18 0.02 250);
-  --destructive: oklch(0.68 0.18 22);
-  --destructive-foreground: oklch(0.17 0.02 248);
+  --destructive: oklch(0.62 0.21 22);
+  --destructive-foreground: oklch(0.98 0.01 90);
   --border: oklch(0.35 0.03 246);
   --input: oklch(0.25 0.03 246);
-  --ring: oklch(0.71 0.15 174);
-  --chart-1: oklch(0.71 0.15 174);
+  --ring: #d4243a;
+  --chart-1: #d4243a;
   --chart-2: oklch(0.82 0.11 80);
   --chart-3: oklch(0.62 0.14 240);
   --chart-4: oklch(0.72 0.18 28);
@@ -35,18 +35,18 @@
   --radius: 0.9rem;
   --sidebar: oklch(0.2 0.03 248);
   --sidebar-foreground: oklch(0.94 0.01 92);
-  --sidebar-primary: oklch(0.71 0.15 174);
-  --sidebar-primary-foreground: oklch(0.16 0.03 248);
+  --sidebar-primary: #d4243a;
+  --sidebar-primary-foreground: oklch(0.98 0.01 90);
   --sidebar-accent: oklch(0.25 0.03 246);
   --sidebar-accent-foreground: oklch(0.94 0.01 92);
   --sidebar-border: oklch(0.35 0.03 246);
-  --sidebar-ring: oklch(0.71 0.15 174);
-  --color-accent-strong: #2dcfb0;
+  --sidebar-ring: #d4243a;
+  --color-accent-strong: #d4243a;
   --color-accent-warm: #f6c465;
 }
 
 @theme inline {
-  --font-sans: 'Space Grotesk', sans-serif;
+  --font-sans: 'Hanken Grotesk', sans-serif;
   --font-mono: 'IBM Plex Mono', monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -103,8 +103,8 @@
     @apply m-0 bg-background text-foreground;
     font-family: var(--font-sans);
     background:
-      radial-gradient(circle at top left, rgba(45, 207, 176, 0.12), transparent 26rem),
-      radial-gradient(circle at 82% 0%, rgba(246, 196, 101, 0.12), transparent 22rem),
+      radial-gradient(circle at top left, rgba(212, 36, 58, 0.13), transparent 26rem),
+      radial-gradient(circle at 82% 0%, rgba(212, 36, 58, 0.08), transparent 22rem),
       linear-gradient(180deg, #0c1628 0%, #07111f 100%);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Summary
- Update brand palette in `styles.css` (teal → red `#d4243a`, Hanken Grotesk font)
- Add semantic color tokens: `--color-positive`, `--color-negative`, `--color-warning` (+ `-foreground` variants) and `--color-accent-strong-soft`
- Replace hardcoded hex values and Tailwind color literals (`emerald-*`, `rose-*`, `amber-*`, `#1fd79a`, `#d4243a`, `#f0586a`) across trading components, badge, alerts, and the risk-disclaimer dialog
- Resolve `--color-positive` / `--color-negative` at runtime in `market-price-chart.tsx` for the lightweight-charts series (which take raw color strings)

## Test plan
- [ ] Verify brand red is consistent across primary buttons, progress bars, charts
- [ ] Verify green / red candles and volume bars in MarketPriceChart
- [ ] Verify positive/negative badge colors render correctly
- [ ] Verify amber warning alerts render correctly (low-SOL warning, reclaim-rent warning)
- [ ] Verify RiskDisclaimerDialog amber accent renders correctly
- [ ] Verify mini price chart line/average colors in closed positions list

🤖 Generated with [Claude Code](https://claude.com/claude-code)