### PR TITLE
feat: show reclaim rent banner

### DIFF
--- a/src/features/trading/components/reclaim-rent-banner.tsx
+++ b/src/features/trading/components/reclaim-rent-banner.tsx
@@ -1,0 +1,54 @@
+import { AlertTriangle, HandCoins } from 'lucide-react'
+import { Alert } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+
+export function ReclaimRentBanner({
+  closeableCount,
+  isReclaiming,
+  nativeSolWarning,
+  onReclaim,
+}: {
+  closeableCount: number
+  isReclaiming: boolean
+  nativeSolWarning: string | null
+  onReclaim: () => void
+}) {
+  if (closeableCount <= 0) return null
+
+  const accountLabel = closeableCount === 1 ? 'account' : 'accounts'
+
+  return (
+    <Alert className="mb-5 border-warning/40 bg-warning/10 text-warning-foreground shadow-none">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-warning/15 text-warning-foreground">
+            <HandCoins className="size-4.5" />
+          </span>
+          <div className="min-w-0 space-y-1">
+            <p className="font-medium text-foreground">
+              Rent is ready to reclaim
+            </p>
+            <p className="text-sm leading-6">
+              Close {closeableCount} stale market {accountLabel} and return the
+              rent to your wallet.
+            </p>
+            {nativeSolWarning ? (
+              <p className="flex items-start gap-2 text-xs leading-5">
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                <span>{nativeSolWarning}</span>
+              </p>
+            ) : null}
+          </div>
+        </div>
+        <Button
+          className="w-full rounded-full sm:w-auto"
+          disabled={isReclaiming}
+          onClick={onReclaim}
+        >
+          {isReclaiming ? 'Reclaiming...' : 'Reclaim rent'}
+          <HandCoins className="size-4" />
+        </Button>
+      </div>
+    </Alert>
+  )
+}

--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -43,6 +43,7 @@ import { useWalletSolBalance } from '../hooks/use-wallet-sol-balance'
 import { useWalletTokenBalance } from '../hooks/use-wallet-token-balance'
 import { useSubmitOrder } from '../hooks/use-submit-order'
 import { useClosePosition } from '../hooks/use-close-position'
+import { useReclaimRent } from '../hooks/use-reclaim-rent'
 import {
   buildTradingDashboardViewModel,
   deriveMarketIdentity,
@@ -53,6 +54,7 @@ import { OrderEntryCard } from './order-entry-card'
 import { ActivePositionCard } from './active-position-card'
 import { ClosedPositionsList } from './closed-positions-list'
 import { PositionPagination } from './position-pagination'
+import { ReclaimRentBanner } from './reclaim-rent-banner'
 import type {
   ChartCrosshairData,
   ChartHistoryRequest,
@@ -101,6 +103,7 @@ export function TradingDashboard() {
 
   const submitOrder = useSubmitOrder()
   const closePosition = useClosePosition()
+  const reclaimRent = useReclaimRent(walletConnection.connected)
 
   const {
     baseDecimals,
@@ -176,6 +179,9 @@ export function TradingDashboard() {
     : null
   const lowMaintenanceNativeSolWarning = hasLowMaintenanceNativeSolBalance
     ? `Your wallet has ${nativeSolBalanceDisplay} SOL. Add SOL before closing positions; at least ${requiredMaintenanceNativeSolDisplay} SOL is required for fees.`
+    : null
+  const lowReclaimRentNativeSolWarning = hasLowMaintenanceNativeSolBalance
+    ? `Your wallet has ${nativeSolBalanceDisplay} SOL. Add SOL before reclaiming rent; at least ${requiredMaintenanceNativeSolDisplay} SOL is required for fees.`
     : null
 
   const amountUiValue = useMemo(() => {
@@ -371,6 +377,38 @@ export function TradingDashboard() {
     })
   }, [closePosition.error])
 
+  useEffect(() => {
+    const signature = reclaimRent.signature
+    if (reclaimRent.status !== 'success' || !signature) return
+
+    toast.success('Rent reclaimed', {
+      action: {
+        label: 'View',
+        onClick: () => {
+          window.open(
+            formatExplorerTransactionUrl(signature, endpoint),
+            '_blank',
+            'noopener,noreferrer',
+          )
+        },
+      },
+      description: `Reclaimed ${formatAtoms(
+        reclaimRent.reclaimedLamports,
+        NATIVE_SOL_DECIMALS,
+      )} SOL.`,
+      id: `reclaim-rent-success-${signature}`,
+    })
+  }, [reclaimRent.reclaimedLamports, reclaimRent.signature, reclaimRent.status])
+
+  useEffect(() => {
+    if (!reclaimRent.error) return
+
+    toast.error('Rent reclaim failed', {
+      description: reclaimRent.error,
+      id: 'reclaim-rent-error',
+    })
+  }, [reclaimRent.error])
+
   const refreshBalances = async () => {
     await Promise.allSettled([
       baseBalance.refresh(),
@@ -489,6 +527,21 @@ export function TradingDashboard() {
     }
   }
 
+  const handleReclaimRent = async () => {
+    if (lowReclaimRentNativeSolWarning) {
+      toast.warning('Not enough SOL', {
+        description: lowReclaimRentNativeSolWarning,
+        id: 'reclaim-rent-validation',
+      })
+      return
+    }
+
+    const success = await reclaimRent.reclaimRent()
+    if (success) {
+      await nativeSolBalance.refresh()
+    }
+  }
+
   return (
     <div className="relative min-h-screen bg-[color:var(--color-page-bg)] text-foreground">
       <div className="relative mx-auto max-w-[1440px] px-4 pb-12 pt-5 sm:px-6 lg:px-8">
@@ -507,6 +560,13 @@ export function TradingDashboard() {
             <span>{lowSubmitNativeSolWarning}</span>
           </Alert>
         ) : null}
+
+        <ReclaimRentBanner
+          closeableCount={reclaimRent.closeableCount}
+          isReclaiming={reclaimRent.isReclaiming}
+          nativeSolWarning={lowReclaimRentNativeSolWarning}
+          onReclaim={() => void handleReclaimRent()}
+        />
 
         <div className="grid grid-cols-1 gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(22rem,0.95fr)]">
           <div className="space-y-6 xl:col-start-2 xl:row-start-1">

--- a/src/features/trading/hooks/use-reclaim-rent.ts
+++ b/src/features/trading/hooks/use-reclaim-rent.ts
@@ -5,7 +5,6 @@ import {
   useSolanaClient,
   useWalletSession,
 } from '@solana/react-hooks'
-import { fetchMarket } from '@/lib/generated/twob/src/generated/accounts'
 import {
   MARKET_ID,
   MAX_RECLAIM_RENT_ACCOUNTS_PER_TRANSACTION,
@@ -20,6 +19,7 @@ import { collectCloseableRentAccounts } from '../lib/rent'
 import { tradingQueryKeys } from '../query-keys'
 import { tradingQueries } from '../queries'
 import { useMarketAddress } from './use-market-address'
+import { fetchMarket } from '@/lib/generated/twob/src/generated/accounts'
 
 type ReclaimRentStatus =
   | 'idle'
@@ -185,9 +185,9 @@ export function useReclaimRent(enabled: boolean) {
         }),
       ])
       return true
-    } catch (error) {
+    } catch (caughtError) {
       setStatus('error')
-      setError(formatTransactionError(error, 'Failed to reclaim rent.'))
+      setError(formatTransactionError(caughtError, 'Failed to reclaim rent.'))
       return false
     }
   }, [client, marketAddress, queryClient, session])


### PR DESCRIPTION
Linear: https://linear.app/nachtschatten-labs/issue/NAC-25/show-reclaim-rent-more-prominently

Summary:
- add a main dashboard banner whenever reclaimable rent accounts are available
- wire the banner to the existing reclaim-rent hook, transaction flow, balance refresh, and explorer-linked success toast
- keep reclaim validation on the 0.001 SOL maintenance fee threshold and clean up lint in the reclaim hook

Validation:
- pnpm exec eslint src/features/trading/components/trading-dashboard.tsx src/features/trading/components/reclaim-rent-banner.tsx src/features/trading/hooks/use-reclaim-rent.ts
- pnpm test
- pnpm build
- git diff --check

Note: in-app browser tooling was not exposed in this session, so local visual smoke could not be run here.