### PR TITLE
feat: animate swap progress bar

### DIFF
--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,15 +1,18 @@
 import { cn } from '@/lib/utils'
 
 export function Progress({
+  animated = false,
   className,
   indicatorClassName,
   value,
 }: {
+  animated?: boolean
   className?: string
   indicatorClassName?: string
   value: number
 }) {
   const clampedValue = Math.max(0, Math.min(100, value))
+  const showActivity = animated && clampedValue > 0 && clampedValue < 100
 
   return (
     <div
@@ -24,11 +27,18 @@ export function Progress({
     >
       <div
         className={cn(
-          'h-full rounded-full bg-primary transition-[width] duration-500',
+          'relative h-full overflow-hidden rounded-full bg-primary transition-[width] duration-500',
           indicatorClassName,
         )}
         style={{ width: `${clampedValue}%` }}
-      />
+      >
+        {showActivity ? (
+          <span
+            aria-hidden="true"
+            className="progress-activity-glow absolute inset-y-0 left-0 w-full"
+          />
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/src/features/trading/components/active-position-card.tsx
+++ b/src/features/trading/components/active-position-card.tsx
@@ -1,15 +1,17 @@
 import { useMemo } from 'react'
-import type { Address } from '@solana/kit'
 import { ArrowUpRight, Waves } from 'lucide-react'
+import { formatAtoms, formatPrice } from '../lib/format'
+import { getActivePositionMetrics } from '../lib/position-progress'
+import { useEndSlotBookkeepingSnapshot } from '../hooks/use-end-slot-bookkeeping-snapshot'
+import type { Address } from '@solana/kit'
+import type {
+  StreamingMarketState,
+  TradePositionRecord,
+} from '../domain/models'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Progress } from '@/components/ui/progress'
-import type { TradePositionRecord } from '../domain/models'
-import { formatAtoms, formatPrice } from '../lib/format'
-import { getActivePositionMetrics } from '../lib/position-progress'
-import { useEndSlotBookkeepingSnapshot } from '../hooks/use-end-slot-bookkeeping-snapshot'
-import type { StreamingMarketState } from '../domain/models'
 
 export function ActivePositionCard({
   baseDecimals,
@@ -102,6 +104,7 @@ export function ActivePositionCard({
         </div>
 
         <Progress
+          animated
           className="h-2.5 bg-white/8"
           indicatorClassName="bg-[linear-gradient(90deg,var(--color-accent-strong),var(--color-accent-strong-soft))]"
           value={metrics.progressPercent}

--- a/src/styles.css
+++ b/src/styles.css
@@ -142,6 +142,36 @@
   }
 }
 
+@keyframes progress-activity {
+  from {
+    transform: translateX(-100%);
+  }
+
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@layer components {
+  .progress-activity-glow {
+    animation: progress-activity 1.4s linear infinite;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      rgba(255, 255, 255, 0) 25%,
+      rgba(255, 255, 255, 0.5) 50%,
+      rgba(255, 255, 255, 0) 75%,
+      transparent 100%
+    );
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .progress-activity-glow {
+      display: none;
+    }
+  }
+}
+
 ::-webkit-scrollbar {
   height: 10px;
   width: 10px;


### PR DESCRIPTION
Linear: https://linear.app/nachtschatten-labs/issue/NAC-26/animate-swap-progress-bar

Summary:
- add an opt-in animated activity layer to the shared progress component
- enable it on active swap position progress bars so long-running streams visibly remain in motion
- suppress the activity layer at 0%, 100%, and for reduced-motion users

Validation:
- pnpm exec eslint src/components/ui/progress.tsx src/features/trading/components/active-position-card.tsx
- pnpm test
- pnpm build
- git diff --check

Note: browser smoke could not be run because the Node REPL browser control tool is not exposed in this session.