### PR TITLE
fix: scope closing position state

### DIFF
--- a/src/features/trading/components/active-position-card.tsx
+++ b/src/features/trading/components/active-position-card.tsx
@@ -16,6 +16,7 @@ import { Progress } from '@/components/ui/progress'
 export function ActivePositionCard({
   baseDecimals,
   baseTicker,
+  isCloseDisabled,
   isClosing,
   marketAddress,
   onClose,
@@ -26,6 +27,7 @@ export function ActivePositionCard({
 }: {
   baseDecimals: number
   baseTicker: string
+  isCloseDisabled: boolean
   isClosing: boolean
   marketAddress: Address
   onClose: (tradePositionAddress: Address) => void
@@ -163,7 +165,7 @@ export function ActivePositionCard({
 
         <Button
           className="w-full rounded-xl bg-destructive/85 text-white hover:bg-destructive"
-          disabled={isClosing}
+          disabled={isCloseDisabled}
           onClick={() => onClose(position.address)}
         >
           {isClosing ? 'Closing position...' : 'Close position'}

--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -789,7 +789,10 @@ export function TradingDashboard() {
                         key={position.address}
                         baseDecimals={baseDecimals}
                         baseTicker={baseTicker}
-                        isClosing={closePosition.isClosing}
+                        isCloseDisabled={closePosition.isClosing}
+                        isClosing={closePosition.isClosingPosition(
+                          position.address,
+                        )}
                         marketAddress={marketAddress}
                         onClose={async (tradePositionAddress) => {
                           if (lowMaintenanceNativeSolWarning) {

--- a/src/features/trading/hooks/use-close-position.ts
+++ b/src/features/trading/hooks/use-close-position.ts
@@ -26,6 +26,9 @@ export function useClosePosition() {
   const [error, setError] = useState<string | null>(null)
   const [signature, setSignature] = useState<string | null>(null)
   const [closedCount, setClosedCount] = useState(0)
+  const [closingPositionAddresses, setClosingPositionAddresses] = useState<
+    Array<string>
+  >([])
 
   const closePosition = useCallback(
     async ({
@@ -38,6 +41,7 @@ export function useClosePosition() {
       if (!session) {
         setStatus('error')
         setError('Connect a wallet to close a position.')
+        setClosingPositionAddresses([])
         return false
       }
 
@@ -45,6 +49,7 @@ export function useClosePosition() {
       setError(null)
       setSignature(null)
       setClosedCount(0)
+      setClosingPositionAddresses([tradePositionAddress.toString()])
 
       try {
         setStatus('submitting')
@@ -85,6 +90,7 @@ export function useClosePosition() {
         setError(
           formatTransactionError(caughtError, 'Failed to close position.'),
         )
+        setClosingPositionAddresses([])
         return false
       }
     },
@@ -102,11 +108,13 @@ export function useClosePosition() {
       if (!session) {
         setStatus('error')
         setError('Connect a wallet to close positions.')
+        setClosingPositionAddresses([])
         return false
       }
       if (tradePositionAddresses.length === 0) {
         setStatus('error')
         setError('Select at least one position to close.')
+        setClosingPositionAddresses([])
         return false
       }
 
@@ -114,6 +122,9 @@ export function useClosePosition() {
       setError(null)
       setSignature(null)
       setClosedCount(0)
+      setClosingPositionAddresses(
+        tradePositionAddresses.map((address) => address.toString()),
+      )
 
       try {
         setStatus('submitting')
@@ -154,6 +165,7 @@ export function useClosePosition() {
         setError(
           formatTransactionError(caughtError, 'Failed to close positions.'),
         )
+        setClosingPositionAddresses([])
         return false
       }
     },
@@ -166,14 +178,24 @@ export function useClosePosition() {
     setError(null)
     setSignature(null)
     setClosedCount(0)
+    setClosingPositionAddresses([])
   }, [sendTransaction])
+
+  const isClosing = status === 'building' || status === 'submitting'
+  const isClosingPosition = useCallback(
+    (tradePositionAddress: Address) =>
+      isClosing &&
+      closingPositionAddresses.includes(tradePositionAddress.toString()),
+    [closingPositionAddresses, isClosing],
+  )
 
   return {
     closePosition,
     closePositions,
     closedCount,
     error,
-    isClosing: status === 'building' || status === 'submitting',
+    isClosing,
+    isClosingPosition,
     reset,
     signature,
     status,


### PR DESCRIPTION
Linear: https://linear.app/nachtschatten-labs/issue/NAC-28/closing-position-button

Summary:
- track the position addresses currently being closed in the close-position hook
- keep all close controls disabled while a close transaction is in flight
- show "Closing position..." only on active position cards whose address is part of the active close request

Validation:
- pnpm exec eslint src/features/trading/hooks/use-close-position.ts src/features/trading/components/active-position-card.tsx src/features/trading/components/trading-dashboard.tsx
- pnpm test
- pnpm build
- git diff --check

Note: browser smoke could not be run because the Node REPL browser control tool is not exposed in this session.