### PR TITLE
feat: show mobile price chart drawer

### DIFF
--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -50,11 +50,11 @@ function DrawerContent({
       <DrawerOverlay />
       <DrawerPrimitive.Viewport
         data-slot="drawer-viewport"
-        className="fixed inset-x-0 bottom-0 z-50 flex max-h-[calc(100dvh-1rem)] justify-center overflow-y-auto p-2 pt-12 duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0"
+        className="fixed inset-x-0 bottom-0 z-50 flex max-h-[100dvh] overflow-y-auto pt-12 duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0"
       >
         <DrawerPrimitive.Popup
           data-slot="drawer-popup"
-          className="w-full outline-none duration-200 data-ending-style:translate-y-full data-starting-style:translate-y-full sm:max-w-2xl"
+          className="w-full outline-none duration-200 data-ending-style:translate-y-full data-starting-style:translate-y-full"
           {...props}
         >
           <DrawerPrimitive.Content

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,0 +1,148 @@
+import * as React from 'react'
+import { Drawer as DrawerPrimitive } from '@base-ui/react/drawer'
+import { XIcon } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+
+function Drawer({ ...props }: DrawerPrimitive.Root.Props) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+}
+
+function DrawerTrigger({ ...props }: DrawerPrimitive.Trigger.Props) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+}
+
+function DrawerPortal({ ...props }: DrawerPrimitive.Portal.Props) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+}
+
+function DrawerClose({ ...props }: DrawerPrimitive.Close.Props) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+}
+
+function DrawerOverlay({
+  className,
+  ...props
+}: DrawerPrimitive.Backdrop.Props) {
+  return (
+    <DrawerPrimitive.Backdrop
+      data-slot="drawer-overlay"
+      className={cn(
+        'fixed inset-0 isolate z-50 bg-black/35 duration-200 supports-backdrop-filter:backdrop-blur-xs data-ending-style:opacity-0 data-starting-style:opacity-0',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DrawerPrimitive.Popup.Props & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Viewport
+        data-slot="drawer-viewport"
+        className="fixed inset-x-0 bottom-0 z-50 flex max-h-[calc(100dvh-1rem)] justify-center overflow-y-auto p-2 pt-12 duration-200 data-ending-style:opacity-0 data-starting-style:opacity-0"
+      >
+        <DrawerPrimitive.Popup
+          data-slot="drawer-popup"
+          className="w-full outline-none duration-200 data-ending-style:translate-y-full data-starting-style:translate-y-full sm:max-w-2xl"
+          {...props}
+        >
+          <DrawerPrimitive.Content
+            data-slot="drawer-content"
+            className={cn(
+              'relative grid gap-4 rounded-t-xl border border-border/60 bg-popover p-4 text-popover-foreground shadow-[0_-20px_80px_-40px_rgba(0,0,0,0.8)] sm:p-5',
+              className,
+            )}
+          >
+            <div className="mx-auto h-1.5 w-12 rounded-full bg-muted-foreground/35" />
+            {children}
+            {showCloseButton && (
+              <DrawerPrimitive.Close
+                data-slot="drawer-close"
+                render={
+                  <Button
+                    variant="ghost"
+                    className="absolute right-3 top-3"
+                    size="icon-sm"
+                  />
+                }
+              >
+                <XIcon />
+                <span className="sr-only">Close</span>
+              </DrawerPrimitive.Close>
+            )}
+          </DrawerPrimitive.Content>
+        </DrawerPrimitive.Popup>
+      </DrawerPrimitive.Viewport>
+    </DrawerPortal>
+  )
+}
+
+function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-header"
+      className={cn('grid gap-1.5 pr-10 text-left', className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="drawer-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+function DrawerTitle({ className, ...props }: DrawerPrimitive.Title.Props) {
+  return (
+    <DrawerPrimitive.Title
+      data-slot="drawer-title"
+      className={cn('text-base font-semibold leading-none', className)}
+      {...props}
+    />
+  )
+}
+
+function DrawerDescription({
+  className,
+  ...props
+}: DrawerPrimitive.Description.Props) {
+  return (
+    <DrawerPrimitive.Description
+      data-slot="drawer-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+}

--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -614,7 +614,7 @@ export function TradingDashboard() {
             <DrawerContent className="xl:hidden">
               <DrawerHeader>
                 <DrawerTitle>
-                  {baseTicker}/{quoteTicker} price chart
+                  {baseTicker}/{quoteTicker}
                 </DrawerTitle>
                 <DrawerDescription>
                   {formatDashboardPrice(displayPrice)}

--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useWalletConnection, useWalletSession } from '@solana/react-hooks'
-import { AlertTriangle, RefreshCcw, X } from 'lucide-react'
+import { AlertTriangle, ChartCandlestick, RefreshCcw, X } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   CHART_TIMEFRAMES,
@@ -58,16 +58,27 @@ import { ClosedPositionsList } from './closed-positions-list'
 import { HighPriceImpactDialog } from './high-price-impact-dialog'
 import { PositionPagination } from './position-pagination'
 import { ReclaimRentBanner } from './reclaim-rent-banner'
+import type { ReactNode } from 'react'
 import type {
   ChartCrosshairData,
   ChartHistoryRequest,
 } from './market-price-chart'
 import type { ChartTimeframe, OrderSide, PositionPanelTab } from '../constants'
 import type { TradePositionRecord } from '../domain/models'
+import type { TradingViewAggregatedCandle } from '../lib/market'
 import { endpoint } from '@/integrations/solana'
 import { Alert } from '@/components/ui/alert'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer'
+import { cn } from '@/lib/utils'
 
 const DEFAULT_VISIBLE_BARS_BY_TIMEFRAME: Record<ChartTimeframe, number> = {
   '1m': 120,
@@ -578,13 +589,60 @@ export function TradingDashboard() {
   return (
     <div className="relative min-h-screen bg-[color:var(--color-page-bg)] text-foreground">
       <div className="relative mx-auto max-w-[1440px] px-4 pb-12 pt-5 sm:px-6 lg:px-8">
-        <div className="mb-5 flex items-baseline gap-3">
-          <h1 className="text-xl font-semibold tracking-[-0.04em] sm:text-2xl">
-            {baseTicker}/{quoteTicker}
-          </h1>
-          <span className="text-xl font-semibold tracking-[-0.04em] text-[color:var(--color-accent-strong)] sm:text-2xl">
-            {formatDashboardPrice(displayPrice)}
-          </span>
+        <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 items-baseline gap-3">
+            <h1 className="text-xl font-semibold tracking-[-0.04em] sm:text-2xl">
+              {baseTicker}/{quoteTicker}
+            </h1>
+            <span className="text-xl font-semibold tracking-[-0.04em] text-[color:var(--color-accent-strong)] sm:text-2xl">
+              {formatDashboardPrice(displayPrice)}
+            </span>
+          </div>
+          <Drawer>
+            <DrawerTrigger
+              render={
+                <Button
+                  className="rounded-full xl:hidden"
+                  size="sm"
+                  variant="outline"
+                />
+              }
+            >
+              <ChartCandlestick className="size-4" />
+              Chart
+            </DrawerTrigger>
+            <DrawerContent className="xl:hidden">
+              <DrawerHeader>
+                <DrawerTitle>
+                  {baseTicker}/{quoteTicker} price chart
+                </DrawerTitle>
+                <DrawerDescription>
+                  {formatDashboardPrice(displayPrice)}
+                </DrawerDescription>
+              </DrawerHeader>
+              <PriceChartPanel
+                chartCandles={chartCandles}
+                chartHeight={360}
+                chartTimeframe={chartTimeframe}
+                hasMoreHistory={marketChartHistory.hasMoreHistory}
+                isLoadingMoreHistory={marketChartHistory.isLoadingMoreHistory}
+                isMarketUpdatesLoading={marketUpdates.isLoading}
+                marketAddressError={
+                  marketAddressQuery.error instanceof Error
+                    ? marketAddressQuery.error.message
+                    : null
+                }
+                marketChartHistoryError={marketChartHistory.error}
+                marketUpdatesError={marketUpdates.error}
+                onCrosshairMove={setCrosshairData}
+                onNeedOlderHistory={handleNeedOlderChartHistory}
+                onReset={() => setChartResetSignal((previous) => previous + 1)}
+                onTimeframeChange={setChartTimeframe}
+                resetSignal={chartResetSignal}
+                statusMinHeightClassName="min-h-[360px]"
+              />
+            </DrawerContent>
+          </Drawer>
         </div>
 
         {lowSubmitNativeSolWarning ? (
@@ -636,80 +694,28 @@ export function TradingDashboard() {
 
           <div className="space-y-6 xl:col-start-1 xl:row-start-1">
             <Card className="hidden border-white/10 bg-black/15 xl:block">
-              <CardContent className="space-y-4 p-4">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div className="flex flex-wrap gap-2">
-                    {CHART_TIMEFRAMES.map((timeframe) => (
-                      <Button
-                        key={timeframe.label}
-                        className="rounded-full"
-                        onClick={() => setChartTimeframe(timeframe.label)}
-                        size="xs"
-                        variant={
-                          chartTimeframe === timeframe.label
-                            ? 'default'
-                            : 'outline'
-                        }
-                      >
-                        {timeframe.label}
-                      </Button>
-                    ))}
-                  </div>
-                  <Button
-                    className="rounded-full"
-                    onClick={() =>
-                      setChartResetSignal((previous) => previous + 1)
-                    }
-                    size="xs"
-                    variant="outline"
-                  >
-                    <RefreshCcw className="size-3.5" />
-                    Reset
-                  </Button>
-                </div>
-
-                {marketUpdates.isLoading && chartCandles.length === 0 ? (
-                  <div className="flex min-h-[420px] items-center justify-center rounded-[1.5rem] border border-white/8 bg-white/5 text-sm text-muted-foreground">
-                    Loading market history...
-                  </div>
-                ) : chartCandles.length === 0 ? (
-                  <div className="flex min-h-[420px] items-center justify-center rounded-[1.5rem] border border-white/8 bg-white/5 text-sm text-muted-foreground">
-                    Not enough market updates to render the chart yet.
-                  </div>
-                ) : (
-                  <div className="overflow-hidden rounded-[1.5rem] border border-white/8 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.06),rgba(255,255,255,0)_55%)]">
-                    <MarketPriceChart
-                      defaultVisibleBars={
-                        DEFAULT_VISIBLE_BARS_BY_TIMEFRAME[chartTimeframe]
-                      }
-                      data={chartCandles}
-                      hasMoreHistory={marketChartHistory.hasMoreHistory}
-                      isLoadingMoreHistory={
-                        marketChartHistory.isLoadingMoreHistory
-                      }
-                      onCrosshairMove={setCrosshairData}
-                      onNeedOlderHistory={handleNeedOlderChartHistory}
-                      resetSignal={chartResetSignal}
-                      viewportPresetKey={chartTimeframe}
-                    />
-                  </div>
-                )}
-
-                {marketUpdates.error ? (
-                  <p className="text-sm text-destructive">
-                    {marketUpdates.error}
-                  </p>
-                ) : null}
-                {marketChartHistory.error ? (
-                  <p className="text-sm text-destructive">
-                    {marketChartHistory.error}
-                  </p>
-                ) : null}
-                {marketAddressQuery.error instanceof Error ? (
-                  <p className="text-sm text-destructive">
-                    {marketAddressQuery.error.message}
-                  </p>
-                ) : null}
+              <CardContent className="p-4">
+                <PriceChartPanel
+                  chartCandles={chartCandles}
+                  chartTimeframe={chartTimeframe}
+                  hasMoreHistory={marketChartHistory.hasMoreHistory}
+                  isLoadingMoreHistory={marketChartHistory.isLoadingMoreHistory}
+                  isMarketUpdatesLoading={marketUpdates.isLoading}
+                  marketAddressError={
+                    marketAddressQuery.error instanceof Error
+                      ? marketAddressQuery.error.message
+                      : null
+                  }
+                  marketChartHistoryError={marketChartHistory.error}
+                  marketUpdatesError={marketUpdates.error}
+                  onCrosshairMove={setCrosshairData}
+                  onNeedOlderHistory={handleNeedOlderChartHistory}
+                  onReset={() =>
+                    setChartResetSignal((previous) => previous + 1)
+                  }
+                  onTimeframeChange={setChartTimeframe}
+                  resetSignal={chartResetSignal}
+                />
               </CardContent>
             </Card>
 
@@ -866,6 +872,128 @@ function EmptyState({ copy }: { copy: string }) {
         {copy}
       </CardContent>
     </Card>
+  )
+}
+
+function PriceChartPanel({
+  chartCandles,
+  chartHeight = 420,
+  chartTimeframe,
+  className,
+  hasMoreHistory,
+  isLoadingMoreHistory,
+  isMarketUpdatesLoading,
+  marketAddressError,
+  marketChartHistoryError,
+  marketUpdatesError,
+  onCrosshairMove,
+  onNeedOlderHistory,
+  onReset,
+  onTimeframeChange,
+  resetSignal,
+  statusMinHeightClassName = 'min-h-[420px]',
+}: {
+  chartCandles: Array<TradingViewAggregatedCandle>
+  chartHeight?: number
+  chartTimeframe: ChartTimeframe
+  className?: string
+  hasMoreHistory: boolean
+  isLoadingMoreHistory: boolean
+  isMarketUpdatesLoading: boolean
+  marketAddressError: string | null
+  marketChartHistoryError: string | null
+  marketUpdatesError: string | null
+  onCrosshairMove: (value: ChartCrosshairData | null) => void
+  onNeedOlderHistory: (request: ChartHistoryRequest) => void
+  onReset: () => void
+  onTimeframeChange: (timeframe: ChartTimeframe) => void
+  resetSignal: number
+  statusMinHeightClassName?: string
+}) {
+  return (
+    <div className={cn('space-y-4', className)}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap gap-2">
+          {CHART_TIMEFRAMES.map((timeframe) => (
+            <Button
+              key={timeframe.label}
+              className="rounded-full"
+              onClick={() => onTimeframeChange(timeframe.label)}
+              size="xs"
+              variant={
+                chartTimeframe === timeframe.label ? 'default' : 'outline'
+              }
+            >
+              {timeframe.label}
+            </Button>
+          ))}
+        </div>
+        <Button
+          className="rounded-full"
+          onClick={onReset}
+          size="xs"
+          variant="outline"
+        >
+          <RefreshCcw className="size-3.5" />
+          Reset
+        </Button>
+      </div>
+
+      {isMarketUpdatesLoading && chartCandles.length === 0 ? (
+        <ChartState className={statusMinHeightClassName}>
+          Loading market history...
+        </ChartState>
+      ) : chartCandles.length === 0 ? (
+        <ChartState className={statusMinHeightClassName}>
+          Not enough market updates to render the chart yet.
+        </ChartState>
+      ) : (
+        <div className="overflow-hidden rounded-[1.5rem] border border-white/8 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.06),rgba(255,255,255,0)_55%)]">
+          <MarketPriceChart
+            defaultVisibleBars={
+              DEFAULT_VISIBLE_BARS_BY_TIMEFRAME[chartTimeframe]
+            }
+            data={chartCandles}
+            hasMoreHistory={hasMoreHistory}
+            height={chartHeight}
+            isLoadingMoreHistory={isLoadingMoreHistory}
+            onCrosshairMove={onCrosshairMove}
+            onNeedOlderHistory={onNeedOlderHistory}
+            resetSignal={resetSignal}
+            viewportPresetKey={chartTimeframe}
+          />
+        </div>
+      )}
+
+      {marketUpdatesError ? (
+        <p className="text-sm text-destructive">{marketUpdatesError}</p>
+      ) : null}
+      {marketChartHistoryError ? (
+        <p className="text-sm text-destructive">{marketChartHistoryError}</p>
+      ) : null}
+      {marketAddressError ? (
+        <p className="text-sm text-destructive">{marketAddressError}</p>
+      ) : null}
+    </div>
+  )
+}
+
+function ChartState({
+  children,
+  className,
+}: {
+  children: ReactNode
+  className?: string
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center rounded-[1.5rem] border border-white/8 bg-white/5 text-center text-sm text-muted-foreground',
+        className,
+      )}
+    >
+      {children}
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- Add a shadcn-style drawer wrapper backed by Base UI drawer primitives.
- Add a mobile-only Chart trigger in the trading header that opens the price chart in a bottom drawer.
- Reuse one chart panel for desktop and mobile so timeframe/reset/loading/error behavior stays aligned.

## Validation
- pnpm exec prettier --write src/components/ui/drawer.tsx src/features/trading/components/trading-dashboard.tsx
- pnpm exec eslint src/components/ui/drawer.tsx src/features/trading/components/trading-dashboard.tsx
- pnpm test
- pnpm build
- git diff --check

## Browser Smoke
- Not run: the required in-app Browser Node bridge was not exposed in this session after tool discovery.

Linear: https://linear.app/nachtschatten-labs/issue/NAC-29/show-price-chart-in-mobile-view