### PR TITLE
feat: show wallet positions on price chart

### DIFF
--- a/src/features/trading/api/market-repository.ts
+++ b/src/features/trading/api/market-repository.ts
@@ -1,14 +1,14 @@
+import { readApiUrl } from './read-api'
 import type {
   MarketConfigRow,
   MarketUpdateEvent,
 } from '@/integrations/supabase'
+import type { MarketPriceSnapshot } from '../domain/models'
 import {
   parseClosePositionEvent,
   parseMarketUpdateEvent,
   supabase,
 } from '@/integrations/supabase'
-import { readApiUrl } from './read-api'
-import type { MarketPriceSnapshot } from '../domain/models'
 
 export type CandleInterval = '1m' | '5m' | '1h'
 const MAX_LIGHTWEIGHT_CHART_ABS_VALUE = 90_071_992_547_409.91
@@ -476,10 +476,12 @@ async function fetchMarketUpdateRangeFromReadApi({
 }
 
 export async function fetchClosedPositionEvents({
+  createdAfter,
   limit = 50,
   marketId,
   positionAuthority,
 }: {
+  createdAfter?: string
   limit?: number
   marketId?: number
   positionAuthority: string
@@ -493,6 +495,10 @@ export async function fetchClosedPositionEvents({
 
   if (marketId !== undefined) {
     request = request.eq('market_id', marketId)
+  }
+
+  if (createdAfter !== undefined) {
+    request = request.gte('created_at', createdAfter)
   }
 
   const { data, error } = await request

--- a/src/features/trading/components/market-price-chart.tsx
+++ b/src/features/trading/components/market-price-chart.tsx
@@ -5,7 +5,7 @@ import {
   HistogramSeries,
   createChart,
 } from 'lightweight-charts'
-import { useEffect, useEffectEvent, useMemo, useRef } from 'react'
+import { useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
 import {
   buildOlderChartHistoryRequest,
   computePrependedLogicalRange,
@@ -16,11 +16,13 @@ import type {
   HistogramData,
   IChartApi,
   ISeriesApi,
+  ITimeScaleApi,
   Logical,
   LogicalRange,
   UTCTimestamp,
 } from 'lightweight-charts'
 import type { LogicalRangeLike } from '../lib/chart-history'
+import type { ChartPositionOverlay } from '../lib/chart-positions'
 import type { TradingViewAggregatedCandle } from '../lib/market'
 
 export interface ChartCrosshairData {
@@ -79,6 +81,18 @@ function isSameCrosshairData(
 const MIN_VALID_UNIX_TIME_SECONDS = 946684800 // 2000-01-01T00:00:00Z
 const MAX_VALID_UNIX_TIME_SECONDS = 4102444800 // 2100-01-01T00:00:00Z
 const MAX_LIGHTWEIGHT_CHART_ABS_VALUE = 90_071_992_547_409.91
+const POSITION_BADGE_HEIGHT = 24
+const POSITION_BADGE_GAP = 4
+
+interface ProjectedPositionOverlay extends ChartPositionOverlay {
+  badgeLeft: number
+  badgeTop: number
+  endX: number
+  lineColor: string
+  startX: number
+  width: number
+  y: number
+}
 
 function normalizeUnixTimeSeconds(rawTime: number) {
   if (!Number.isFinite(rawTime) || rawTime <= 0) {
@@ -184,6 +198,147 @@ function sanitizeChartCandles(data: Array<TradingViewAggregatedCandle>) {
   return deduped
 }
 
+function getInterpolatedTimeCoordinate({
+  chartData,
+  time,
+  timeScale,
+}: {
+  chartData: Array<TradingViewAggregatedCandle>
+  time: number
+  timeScale: ITimeScaleApi<UTCTimestamp>
+}) {
+  const directCoordinate = timeScale.timeToCoordinate(time as UTCTimestamp)
+  if (directCoordinate !== null) {
+    return directCoordinate
+  }
+
+  if (chartData.length === 0) return null
+
+  const upperIndex = chartData.findIndex((candle) => candle.time >= time)
+  if (upperIndex >= 0 && chartData[upperIndex].time === time) {
+    return timeScale.timeToCoordinate(
+      chartData[upperIndex].time as UTCTimestamp,
+    )
+  }
+
+  const left =
+    upperIndex < 0
+      ? chartData.at(-2)
+      : upperIndex === 0
+        ? chartData[0]
+        : chartData[upperIndex - 1]
+  const right =
+    upperIndex < 0
+      ? chartData.at(-1)
+      : upperIndex === 0
+        ? chartData[1]
+        : chartData[upperIndex]
+
+  if (!left || !right || left.time === right.time) {
+    return null
+  }
+
+  const leftX = timeScale.timeToCoordinate(left.time as UTCTimestamp)
+  const rightX = timeScale.timeToCoordinate(right.time as UTCTimestamp)
+  if (leftX === null || rightX === null) {
+    return null
+  }
+
+  const ratio = (time - left.time) / (right.time - left.time)
+  return leftX + (rightX - leftX) * ratio
+}
+
+function estimateBadgeWidth(label: string) {
+  return Math.min(168, Math.max(80, label.length * 7 + 24))
+}
+
+function boxesOverlap(
+  left: { bottom: number; left: number; right: number; top: number },
+  right: { bottom: number; left: number; right: number; top: number },
+) {
+  return (
+    left.left < right.right &&
+    left.right > right.left &&
+    left.top < right.bottom &&
+    left.bottom > right.top
+  )
+}
+
+function stackPositionBadges({
+  bounds,
+  overlays,
+}: {
+  bounds: { height: number; width: number }
+  overlays: Array<Omit<ProjectedPositionOverlay, 'badgeLeft' | 'badgeTop'>>
+}): Array<ProjectedPositionOverlay> {
+  const occupied: Array<{
+    bottom: number
+    left: number
+    right: number
+    top: number
+  }> = []
+
+  return [...overlays]
+    .sort((left, right) => {
+      if (Math.abs(left.startX - right.startX) < 1) return left.y - right.y
+      return left.startX - right.startX
+    })
+    .map((overlay) => {
+      const badgeWidth = estimateBadgeWidth(overlay.label)
+      const badgeLeft = Math.min(
+        Math.max(overlay.startX - badgeWidth / 2, 4),
+        Math.max(4, bounds.width - badgeWidth - 4),
+      )
+      const preferredTop = Math.min(
+        Math.max(overlay.y - POSITION_BADGE_HEIGHT - 8, 4),
+        Math.max(4, bounds.height - POSITION_BADGE_HEIGHT - 4),
+      )
+      let badgeTop = preferredTop
+
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        const candidate = {
+          bottom: badgeTop + POSITION_BADGE_HEIGHT,
+          left: badgeLeft,
+          right: badgeLeft + badgeWidth,
+          top: badgeTop,
+        }
+        if (!occupied.some((box) => boxesOverlap(candidate, box))) {
+          occupied.push(candidate)
+          return {
+            ...overlay,
+            badgeLeft,
+            badgeTop,
+            width: badgeWidth,
+          }
+        }
+
+        const nextTop =
+          attempt < 6
+            ? preferredTop -
+              (attempt + 1) * (POSITION_BADGE_HEIGHT + POSITION_BADGE_GAP)
+            : preferredTop +
+              (attempt - 5) * (POSITION_BADGE_HEIGHT + POSITION_BADGE_GAP)
+        badgeTop = Math.min(
+          Math.max(nextTop, 4),
+          Math.max(4, bounds.height - POSITION_BADGE_HEIGHT - 4),
+        )
+      }
+
+      occupied.push({
+        bottom: badgeTop + POSITION_BADGE_HEIGHT,
+        left: badgeLeft,
+        right: badgeLeft + badgeWidth,
+        top: badgeTop,
+      })
+      return {
+        ...overlay,
+        badgeLeft,
+        badgeTop,
+        width: badgeWidth,
+      }
+    })
+}
+
 export function MarketPriceChart({
   defaultVisibleBars = 120,
   data,
@@ -192,6 +347,7 @@ export function MarketPriceChart({
   isLoadingMoreHistory = false,
   onCrosshairMove,
   onNeedOlderHistory,
+  positionOverlays = [],
   resetSignal = 0,
   viewportPresetKey = 'default',
 }: {
@@ -202,6 +358,7 @@ export function MarketPriceChart({
   isLoadingMoreHistory?: boolean
   onCrosshairMove?: (value: ChartCrosshairData | null) => void
   onNeedOlderHistory?: (request: ChartHistoryRequest) => void
+  positionOverlays?: Array<ChartPositionOverlay>
   resetSignal?: number
   viewportPresetKey?: string
 }) {
@@ -231,6 +388,9 @@ export function MarketPriceChart({
   const lastCrosshairDataRef = useRef<ChartCrosshairData | null>(null)
   const previousViewportPresetKeyRef = useRef(viewportPresetKey)
   const chartData = useMemo(() => sanitizeChartCandles(data), [data])
+  const [projectedPositionOverlays, setProjectedPositionOverlays] = useState<
+    Array<ProjectedPositionOverlay>
+  >([])
 
   const histogramData = useMemo(
     () =>
@@ -266,6 +426,62 @@ export function MarketPriceChart({
       onCrosshairMove?.(payload)
     },
   )
+  const updatePositionOverlayCoordinates = useEffectEvent(() => {
+    if (
+      !chartRef.current ||
+      !candleSeriesRef.current ||
+      !containerRef.current ||
+      chartData.length === 0 ||
+      positionOverlays.length === 0
+    ) {
+      setProjectedPositionOverlays([])
+      return
+    }
+
+    const timeScale = chartRef.current.timeScale()
+    const bounds = {
+      height: containerRef.current.clientHeight,
+      width: containerRef.current.clientWidth,
+    }
+    const projected = positionOverlays.flatMap<
+      Omit<ProjectedPositionOverlay, 'badgeLeft' | 'badgeTop'>
+    >((overlay) => {
+      const startX = getInterpolatedTimeCoordinate({
+        chartData,
+        time: overlay.startTime,
+        timeScale,
+      })
+      const endX = getInterpolatedTimeCoordinate({
+        chartData,
+        time: overlay.endTime,
+        timeScale,
+      })
+      const y = candleSeriesRef.current?.priceToCoordinate(overlay.averagePrice)
+
+      if (startX === null || endX === null || y === null) {
+        return []
+      }
+
+      const lineEndX = endX <= startX ? startX + 8 : endX
+      return [
+        {
+          ...overlay,
+          endX: lineEndX,
+          lineColor:
+            overlay.side === 'buy'
+              ? seriesColors.positive
+              : seriesColors.negative,
+          startX,
+          width: 0,
+          y,
+        },
+      ]
+    })
+
+    setProjectedPositionOverlays(
+      stackPositionBadges({ bounds, overlays: projected }),
+    )
+  })
   const handleNeedOlderHistory = useEffectEvent(
     (range: LogicalRange | null) => {
       if (
@@ -447,9 +663,14 @@ export function MarketPriceChart({
         volume: volume?.value ?? null,
       })
     })
-    chart.timeScale().subscribeVisibleLogicalRangeChange((range) => {
+    const handleVisibleLogicalRangeChange = (range: LogicalRange | null) => {
       handleNeedOlderHistory(range)
-    })
+      updatePositionOverlayCoordinates()
+    }
+    chart
+      .timeScale()
+      .subscribeVisibleLogicalRangeChange(handleVisibleLogicalRangeChange)
+    chart.timeScale().subscribeSizeChange(updatePositionOverlayCoordinates)
 
     chartRef.current = chart
     candleSeriesRef.current = candleSeries
@@ -512,6 +733,7 @@ export function MarketPriceChart({
 
     const resizeObserver = new ResizeObserver(() => {
       chart.timeScale().applyOptions({ rightOffset: 8 })
+      updatePositionOverlayCoordinates()
     })
     resizeObserver.observe(containerRef.current)
 
@@ -523,6 +745,10 @@ export function MarketPriceChart({
       )
       window.removeEventListener('pointerup', clearPanGesture)
       window.removeEventListener('pointercancel', clearPanGesture)
+      chart
+        .timeScale()
+        .unsubscribeVisibleLogicalRangeChange(handleVisibleLogicalRangeChange)
+      chart.timeScale().unsubscribeSizeChange(updatePositionOverlayCoordinates)
       containerRef.current?.removeEventListener('wheel', handleWheel)
       containerRef.current?.removeEventListener('touchstart', handleTouchStart)
       containerRef.current?.removeEventListener('touchend', handleTouchEnd)
@@ -544,6 +770,7 @@ export function MarketPriceChart({
         window.clearTimeout(wheelGestureTimeoutRef.current)
         wheelGestureTimeoutRef.current = null
       }
+      setProjectedPositionOverlays([])
     }
   }, [height, seriesColors])
 
@@ -625,6 +852,7 @@ export function MarketPriceChart({
           lastLogicalRangeRef.current = chartRef.current
             .timeScale()
             .getVisibleLogicalRange()
+          updatePositionOverlayCoordinates()
           return
         }
       }
@@ -645,6 +873,7 @@ export function MarketPriceChart({
       lastLogicalRangeRef.current = chartRef.current
         .timeScale()
         .getVisibleLogicalRange()
+      updatePositionOverlayCoordinates()
       return
     }
 
@@ -654,6 +883,7 @@ export function MarketPriceChart({
     previousLastTimeRef.current = null
     lastLogicalRangeRef.current = null
     handleCrosshairMove(null)
+    updatePositionOverlayCoordinates()
   }, [
     candleData,
     chartData,
@@ -667,15 +897,58 @@ export function MarketPriceChart({
     if (!chartRef.current) return
     hasUserInteractedRef.current = false
     applyDefaultViewport()
+    updatePositionOverlayCoordinates()
   }, [resetSignal])
 
   useEffect(() => {
     hasUserInteractedRef.current = false
   }, [viewportPresetKey])
 
+  useEffect(() => {
+    updatePositionOverlayCoordinates()
+  }, [chartData, positionOverlays])
+
   return (
     <div className="relative h-full min-h-[420px] w-full">
       <div ref={containerRef} className="h-full min-h-[420px] w-full" />
+      {projectedPositionOverlays.length > 0 ? (
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          <svg aria-hidden className="absolute inset-0 size-full">
+            {projectedPositionOverlays.map((overlay) => (
+              <line
+                key={`${overlay.id}-line`}
+                stroke={overlay.lineColor}
+                strokeDasharray={
+                  overlay.status === 'active' ? '5 4' : undefined
+                }
+                strokeLinecap="round"
+                strokeWidth="2"
+                x1={overlay.startX}
+                x2={overlay.endX}
+                y1={overlay.y}
+                y2={overlay.y}
+              />
+            ))}
+          </svg>
+          {projectedPositionOverlays.map((overlay) => (
+            <div
+              className={`absolute flex h-6 items-center justify-center rounded-full border px-2 text-[11px] font-semibold shadow-[0_8px_24px_-16px_rgba(0,0,0,0.9)] backdrop-blur-sm ${
+                overlay.side === 'buy'
+                  ? 'border-positive/60 bg-positive/90 text-background'
+                  : 'border-negative/60 bg-negative/90 text-white'
+              }`}
+              key={`${overlay.id}-badge`}
+              style={{
+                left: overlay.badgeLeft,
+                top: overlay.badgeTop,
+                width: overlay.width,
+              }}
+            >
+              <span className="truncate">{overlay.label}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
       {isLoadingMoreHistory ? (
         <div className="pointer-events-none absolute left-4 top-4 rounded-full border border-white/10 bg-black/45 px-3 py-1 text-xs text-muted-foreground backdrop-blur-sm">
           Loading older history...

--- a/src/features/trading/components/market-price-chart.tsx
+++ b/src/features/trading/components/market-price-chart.tsx
@@ -85,10 +85,12 @@ const POSITION_BADGE_HEIGHT = 24
 const POSITION_BADGE_GAP = 4
 
 interface ProjectedPositionOverlay extends ChartPositionOverlay {
+  badgeAnchorX: number
   badgeLeft: number
   badgeTop: number
   endX: number
   lineColor: string
+  showBadge: boolean
   startX: number
   width: number
   y: number
@@ -271,6 +273,11 @@ function stackPositionBadges({
   bounds: { height: number; width: number }
   overlays: Array<Omit<ProjectedPositionOverlay, 'badgeLeft' | 'badgeTop'>>
 }): Array<ProjectedPositionOverlay> {
+  const stackedOverlays = overlays.map((overlay) => ({
+    ...overlay,
+    badgeLeft: 0,
+    badgeTop: 0,
+  }))
   const occupied: Array<{
     bottom: number
     left: number
@@ -278,24 +285,31 @@ function stackPositionBadges({
     top: number
   }> = []
 
-  return [...overlays]
+  stackedOverlays
+    .filter((overlay) => overlay.showBadge)
     .sort((left, right) => {
-      if (Math.abs(left.startX - right.startX) < 1) return left.y - right.y
-      return left.startX - right.startX
+      if (Math.abs(left.badgeAnchorX - right.badgeAnchorX) < 1) {
+        return left.y - right.y
+      }
+      return left.badgeAnchorX - right.badgeAnchorX
     })
-    .map((overlay) => {
+    .forEach((overlay) => {
       const badgeWidth = estimateBadgeWidth(overlay.label)
       const badgeLeft = Math.min(
-        Math.max(overlay.startX - badgeWidth / 2, 4),
+        Math.max(overlay.badgeAnchorX - badgeWidth / 2, 4),
         Math.max(4, bounds.width - badgeWidth - 4),
       )
       const preferredTop = Math.min(
-        Math.max(overlay.y - POSITION_BADGE_HEIGHT - 8, 4),
+        Math.max(overlay.y - POSITION_BADGE_HEIGHT - 14, 4),
         Math.max(4, bounds.height - POSITION_BADGE_HEIGHT - 4),
       )
       let badgeTop = preferredTop
 
       for (let attempt = 0; attempt < 12; attempt += 1) {
+        badgeTop = Math.max(
+          4,
+          preferredTop - attempt * (POSITION_BADGE_HEIGHT + POSITION_BADGE_GAP),
+        )
         const candidate = {
           bottom: badgeTop + POSITION_BADGE_HEIGHT,
           left: badgeLeft,
@@ -304,24 +318,11 @@ function stackPositionBadges({
         }
         if (!occupied.some((box) => boxesOverlap(candidate, box))) {
           occupied.push(candidate)
-          return {
-            ...overlay,
-            badgeLeft,
-            badgeTop,
-            width: badgeWidth,
-          }
+          overlay.badgeLeft = badgeLeft
+          overlay.badgeTop = badgeTop
+          overlay.width = badgeWidth
+          return
         }
-
-        const nextTop =
-          attempt < 6
-            ? preferredTop -
-              (attempt + 1) * (POSITION_BADGE_HEIGHT + POSITION_BADGE_GAP)
-            : preferredTop +
-              (attempt - 5) * (POSITION_BADGE_HEIGHT + POSITION_BADGE_GAP)
-        badgeTop = Math.min(
-          Math.max(nextTop, 4),
-          Math.max(4, bounds.height - POSITION_BADGE_HEIGHT - 4),
-        )
       }
 
       occupied.push({
@@ -330,13 +331,12 @@ function stackPositionBadges({
         right: badgeLeft + badgeWidth,
         top: badgeTop,
       })
-      return {
-        ...overlay,
-        badgeLeft,
-        badgeTop,
-        width: badgeWidth,
-      }
+      overlay.badgeLeft = badgeLeft
+      overlay.badgeTop = badgeTop
+      overlay.width = badgeWidth
     })
+
+  return stackedOverlays
 }
 
 export function MarketPriceChart({
@@ -446,32 +446,46 @@ export function MarketPriceChart({
     const projected = positionOverlays.flatMap<
       Omit<ProjectedPositionOverlay, 'badgeLeft' | 'badgeTop'>
     >((overlay) => {
-      const startX = getInterpolatedTimeCoordinate({
+      const rawStartX = getInterpolatedTimeCoordinate({
         chartData,
         time: overlay.startTime,
         timeScale,
       })
-      const endX = getInterpolatedTimeCoordinate({
+      const rawEndX = getInterpolatedTimeCoordinate({
         chartData,
         time: overlay.endTime,
         timeScale,
       })
       const y = candleSeriesRef.current?.priceToCoordinate(overlay.averagePrice)
 
-      if (startX === null || endX === null || y === null) {
+      if (rawStartX === null || rawEndX === null || y === null) {
         return []
       }
 
-      const lineEndX = endX <= startX ? startX + 8 : endX
+      const rawLineEndX = rawEndX <= rawStartX ? rawStartX + 8 : rawEndX
+      const minLineX = Math.min(rawStartX, rawLineEndX)
+      const maxLineX = Math.max(rawStartX, rawLineEndX)
+
+      if (
+        maxLineX < 0 ||
+        minLineX > bounds.width ||
+        y < 0 ||
+        y > bounds.height
+      ) {
+        return []
+      }
+
       return [
         {
           ...overlay,
-          endX: lineEndX,
+          badgeAnchorX: rawStartX,
+          endX: Math.min(Math.max(rawLineEndX, 0), bounds.width),
           lineColor:
             overlay.side === 'buy'
               ? seriesColors.positive
               : seriesColors.negative,
-          startX,
+          showBadge: rawStartX >= 0 && rawStartX <= bounds.width,
+          startX: Math.min(Math.max(rawStartX, 0), bounds.width),
           width: 0,
           y,
         },
@@ -930,23 +944,25 @@ export function MarketPriceChart({
               />
             ))}
           </svg>
-          {projectedPositionOverlays.map((overlay) => (
-            <div
-              className={`absolute flex h-6 items-center justify-center rounded-full border px-2 text-[11px] font-semibold shadow-[0_8px_24px_-16px_rgba(0,0,0,0.9)] backdrop-blur-sm ${
-                overlay.side === 'buy'
-                  ? 'border-positive/60 bg-positive/90 text-background'
-                  : 'border-negative/60 bg-negative/90 text-white'
-              }`}
-              key={`${overlay.id}-badge`}
-              style={{
-                left: overlay.badgeLeft,
-                top: overlay.badgeTop,
-                width: overlay.width,
-              }}
-            >
-              <span className="truncate">{overlay.label}</span>
-            </div>
-          ))}
+          {projectedPositionOverlays
+            .filter((overlay) => overlay.showBadge)
+            .map((overlay) => (
+              <div
+                className={`absolute z-10 flex h-6 items-center justify-center rounded-full border px-2 text-[11px] font-semibold shadow-[0_8px_24px_-16px_rgba(0,0,0,0.9)] backdrop-blur-sm ${
+                  overlay.side === 'buy'
+                    ? 'border-positive/60 bg-positive/90 text-background'
+                    : 'border-negative/60 bg-negative/90 text-white'
+                }`}
+                key={`${overlay.id}-badge`}
+                style={{
+                  left: overlay.badgeLeft,
+                  top: overlay.badgeTop,
+                  width: overlay.width,
+                }}
+              >
+                <span className="truncate">{overlay.label}</span>
+              </div>
+            ))}
         </div>
       ) : null}
       {isLoadingMoreHistory ? (

--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -41,11 +41,17 @@ import { useMarketPrice } from '../hooks/use-market-price'
 import { useMarketUpdates } from '../hooks/use-market-updates'
 import { useStreamingMarketState } from '../hooks/use-streaming-market-state'
 import { useTradePositions } from '../hooks/use-trade-positions'
+import { useClosedPositionEvents } from '../hooks/use-closed-position-events'
 import { useWalletSolBalance } from '../hooks/use-wallet-sol-balance'
 import { useWalletTokenBalance } from '../hooks/use-wallet-token-balance'
 import { useSubmitOrder } from '../hooks/use-submit-order'
 import { useClosePosition } from '../hooks/use-close-position'
 import { useReclaimRent } from '../hooks/use-reclaim-rent'
+import {
+  buildChartPositionOverlays,
+  buildChartPositionSlotRanges,
+  buildMarketTimeAnchors,
+} from '../lib/chart-positions'
 import {
   buildTradingDashboardViewModel,
   deriveMarketIdentity,
@@ -63,6 +69,7 @@ import type {
   ChartCrosshairData,
   ChartHistoryRequest,
 } from './market-price-chart'
+import type { ChartPositionOverlay } from '../lib/chart-positions'
 import type { ChartTimeframe, OrderSide, PositionPanelTab } from '../constants'
 import type { TradePositionRecord } from '../domain/models'
 import type { TradingViewAggregatedCandle } from '../lib/market'
@@ -85,6 +92,8 @@ const DEFAULT_VISIBLE_BARS_BY_TIMEFRAME: Record<ChartTimeframe, number> = {
   '5m': 96,
   '1h': 72,
 }
+const CHART_POSITION_CLOSED_LOOKBACK_DAYS = 30
+const CHART_POSITION_CLOSED_LIMIT = 1000
 
 export function TradingDashboard() {
   const session = useWalletSession()
@@ -102,6 +111,19 @@ export function TradingDashboard() {
   })
   const streamingStateQuery = useStreamingMarketState(marketAddress)
   const tradePositionsQuery = useTradePositions(address)
+  const closedPositionChartLookbackStart = useMemo(
+    () =>
+      new Date(
+        Date.now() - CHART_POSITION_CLOSED_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
+      ).toISOString(),
+    [],
+  )
+  const closedPositionChartQuery = useClosedPositionEvents({
+    createdAfter: closedPositionChartLookbackStart,
+    limit: CHART_POSITION_CLOSED_LIMIT,
+    marketId: MARKET_ID,
+    positionAuthority: address ?? '',
+  })
 
   const [side, setSide] = useState<OrderSide>('buy')
   const [amountInput, setAmountInput] = useState('')
@@ -209,6 +231,10 @@ export function TradingDashboard() {
     () => tradePositionsQuery.data ?? [],
     [tradePositionsQuery.data],
   )
+  const closedChartPositions = useMemo(
+    () => closedPositionChartQuery.data ?? [],
+    [closedPositionChartQuery.data],
+  )
   const activePositionPageCount = getPageCount(
     activePositions.length,
     POSITION_PAGE_SIZE,
@@ -228,6 +254,77 @@ export function TradingDashboard() {
     [activePositions, normalizedActivePositionPage],
   )
   const currentSlot = streamingStateQuery.data?.currentSlot ?? null
+  const chartPositionSlotRanges = useMemo(
+    () =>
+      buildChartPositionSlotRanges({
+        activePositions,
+        closedPositions: closedChartPositions,
+        currentSlot,
+      }),
+    [activePositions, closedChartPositions, currentSlot],
+  )
+  const chartPositionTimeAnchors = useMemo(
+    () =>
+      buildMarketTimeAnchors({
+        candles: marketChartHistory.candles,
+        chartIntervalMs: marketChartHistory.chartIntervalMs,
+        events: marketUpdates.sharedEvents,
+        extraAnchors: [
+          ...(marketPriceQuery.data?.slot !== null &&
+          marketPriceQuery.data?.slot !== undefined &&
+          marketPriceQuery.data.eventTimeMs !== null
+            ? [
+                {
+                  slot: marketPriceQuery.data.slot,
+                  timeMs: marketPriceQuery.data.eventTimeMs,
+                },
+              ]
+            : []),
+          ...(currentSlot !== null
+            ? [
+                {
+                  slot: currentSlot,
+                  timeMs: Date.now(),
+                },
+              ]
+            : []),
+        ],
+      }),
+    [
+      currentSlot,
+      marketChartHistory.candles,
+      marketChartHistory.chartIntervalMs,
+      marketPriceQuery.data,
+      marketUpdates.sharedEvents,
+    ],
+  )
+  const chartPositionOverlays = useMemo(
+    () =>
+      buildChartPositionOverlays({
+        activePositions,
+        anchors: chartPositionTimeAnchors,
+        baseDecimals,
+        baseTicker,
+        closedPositions: closedChartPositions,
+        currentSlot,
+        marketAddress,
+        quoteDecimals,
+        quoteTicker,
+        streamingState: streamingStateQuery.data ?? null,
+      }),
+    [
+      activePositions,
+      baseDecimals,
+      baseTicker,
+      chartPositionTimeAnchors,
+      closedChartPositions,
+      currentSlot,
+      marketAddress,
+      quoteDecimals,
+      quoteTicker,
+      streamingStateQuery.data,
+    ],
+  )
   const endedPositions = useMemo(
     () =>
       activePositions.filter((position) =>
@@ -344,6 +441,14 @@ export function TradingDashboard() {
       setHighPriceImpactDialogOpen(false)
     }
   }, [hasHighPriceImpact, submitDisabled])
+
+  useEffect(() => {
+    if (chartPositionSlotRanges.length === 0) return
+
+    void marketUpdates.ensureRanges(chartPositionSlotRanges, {
+      reason: 'main-chart',
+    })
+  }, [chartPositionSlotRanges, marketUpdates.ensureRanges])
 
   useEffect(() => {
     const signature = submitOrder.signature
@@ -638,6 +743,12 @@ export function TradingDashboard() {
                 onNeedOlderHistory={handleNeedOlderChartHistory}
                 onReset={() => setChartResetSignal((previous) => previous + 1)}
                 onTimeframeChange={setChartTimeframe}
+                positionOverlayError={
+                  closedPositionChartQuery.error instanceof Error
+                    ? closedPositionChartQuery.error.message
+                    : null
+                }
+                positionOverlays={chartPositionOverlays}
                 resetSignal={chartResetSignal}
                 statusMinHeightClassName="min-h-[360px]"
               />
@@ -714,6 +825,12 @@ export function TradingDashboard() {
                     setChartResetSignal((previous) => previous + 1)
                   }
                   onTimeframeChange={setChartTimeframe}
+                  positionOverlayError={
+                    closedPositionChartQuery.error instanceof Error
+                      ? closedPositionChartQuery.error.message
+                      : null
+                  }
+                  positionOverlays={chartPositionOverlays}
                   resetSignal={chartResetSignal}
                 />
               </CardContent>
@@ -890,6 +1007,8 @@ function PriceChartPanel({
   onNeedOlderHistory,
   onReset,
   onTimeframeChange,
+  positionOverlayError,
+  positionOverlays,
   resetSignal,
   statusMinHeightClassName = 'min-h-[420px]',
 }: {
@@ -907,6 +1026,8 @@ function PriceChartPanel({
   onNeedOlderHistory: (request: ChartHistoryRequest) => void
   onReset: () => void
   onTimeframeChange: (timeframe: ChartTimeframe) => void
+  positionOverlayError: string | null
+  positionOverlays: Array<ChartPositionOverlay>
   resetSignal: number
   statusMinHeightClassName?: string
 }) {
@@ -959,6 +1080,7 @@ function PriceChartPanel({
             isLoadingMoreHistory={isLoadingMoreHistory}
             onCrosshairMove={onCrosshairMove}
             onNeedOlderHistory={onNeedOlderHistory}
+            positionOverlays={positionOverlays}
             resetSignal={resetSignal}
             viewportPresetKey={chartTimeframe}
           />
@@ -973,6 +1095,11 @@ function PriceChartPanel({
       ) : null}
       {marketAddressError ? (
         <p className="text-sm text-destructive">{marketAddressError}</p>
+      ) : null}
+      {positionOverlayError ? (
+        <p className="text-sm text-destructive">
+          Position history unavailable: {positionOverlayError}
+        </p>
       ) : null}
     </div>
   )

--- a/src/features/trading/hooks/use-closed-position-events.ts
+++ b/src/features/trading/hooks/use-closed-position-events.ts
@@ -2,16 +2,19 @@ import { useQuery } from '@tanstack/react-query'
 import { tradingQueries } from '../queries'
 
 export function useClosedPositionEvents({
+  createdAfter,
   positionAuthority,
   marketId,
   limit = 50,
 }: {
+  createdAfter?: string
   positionAuthority: string
   marketId?: number
   limit?: number
 }) {
   return useQuery({
     ...tradingQueries.closedPositions({
+      createdAfter,
       limit,
       marketId,
       positionAuthority,

--- a/src/features/trading/lib/chart-positions.test.ts
+++ b/src/features/trading/lib/chart-positions.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildChartPositionSlotRanges,
+  estimateTimeMsForSlot,
+} from './chart-positions'
+import type { ClosePositionEvent } from '@/integrations/supabase'
+import type { TradePositionRecord } from '../domain/models'
+
+function activePosition({
+  endSlot,
+  startSlot,
+}: {
+  endSlot: bigint
+  startSlot: bigint
+}): TradePositionRecord {
+  return {
+    address: '11111111111111111111111111111111',
+    data: {
+      discriminator: new Uint8Array(),
+      amount: 1_000_000n,
+      authority: '22222222222222222222222222222222',
+      bookkeepingSnapshot: 0n,
+      bump: 255,
+      endSlot,
+      id: 1n,
+      isBuy: 1,
+      slotsWithoutTradesSnapshot: 0n,
+      startSlot,
+    },
+  }
+}
+
+function closedPosition({
+  endSlot,
+  slot,
+  startSlot,
+}: {
+  endSlot: number | null
+  slot: number
+  startSlot: number | null
+}): ClosePositionEvent {
+  return {
+    created_at: '2026-06-05T12:00:00.000Z',
+    deposit_amount: 1_000_000n,
+    end_slot: endSlot,
+    fee_amount: 0n,
+    id: 1,
+    is_buy: 1,
+    market_id: 1,
+    position_authority: 'authority',
+    remaining_amount: 0n,
+    signature: 'signature',
+    slot,
+    start_slot: startSlot,
+    swapped_amount: 1_000_000n,
+  }
+}
+
+describe('estimateTimeMsForSlot', () => {
+  it('interpolates missing slots from surrounding market update anchors', () => {
+    expect(
+      estimateTimeMsForSlot(
+        [
+          { slot: 100, timeMs: 10_000 },
+          { slot: 200, timeMs: 50_000 },
+        ],
+        150,
+      ),
+    ).toBe(30_000)
+  })
+
+  it('extrapolates outside the known anchor range', () => {
+    expect(
+      estimateTimeMsForSlot(
+        [
+          { slot: 100, timeMs: 10_000 },
+          { slot: 200, timeMs: 50_000 },
+        ],
+        250,
+      ),
+    ).toBe(70_000)
+  })
+
+  it('falls back to the default slot duration when only one anchor is known', () => {
+    expect(estimateTimeMsForSlot([{ slot: 100, timeMs: 10_000 }], 105)).toBe(
+      12_000,
+    )
+  })
+})
+
+describe('buildChartPositionSlotRanges', () => {
+  it('uses the current slot for active positions that are still streaming', () => {
+    expect(
+      buildChartPositionSlotRanges({
+        activePositions: [activePosition({ endSlot: 300n, startSlot: 100n })],
+        closedPositions: [],
+        currentSlot: 180,
+      }),
+    ).toEqual([{ endSlot: 180, startSlot: 100 }])
+  })
+
+  it('uses the close slot for closed positions that were closed early', () => {
+    expect(
+      buildChartPositionSlotRanges({
+        activePositions: [],
+        closedPositions: [
+          closedPosition({ endSlot: 300, slot: 240, startSlot: 100 }),
+        ],
+        currentSlot: null,
+      }),
+    ).toEqual([{ endSlot: 240, startSlot: 100 }])
+  })
+})

--- a/src/features/trading/lib/chart-positions.ts
+++ b/src/features/trading/lib/chart-positions.ts
@@ -1,0 +1,295 @@
+import { SLOT_DURATION_MS } from '../constants'
+import { buildClosedPositionSummary } from '../view-models/closed-position'
+import { formatAtoms } from './format'
+import { getActivePositionMetrics } from './position-progress'
+import { mergeAdjacentRanges } from './slot-ranges'
+import type { Address } from '@solana/kit'
+import type {
+  ClosePositionEvent,
+  MarketUpdateEvent,
+} from '@/integrations/supabase'
+import type {
+  StreamingMarketState,
+  TradePositionRecord,
+} from '../domain/models'
+import type { TradingViewAggregatedCandle } from './market'
+import type { SlotRange } from './slot-ranges'
+
+export type ChartPositionSide = 'buy' | 'sell'
+export type ChartPositionStatus = 'active' | 'closed'
+
+export interface SlotTimeAnchor {
+  slot: number
+  timeMs: number
+}
+
+export interface ChartPositionOverlay {
+  averagePrice: number
+  endTime: number
+  id: string
+  label: string
+  side: ChartPositionSide
+  startTime: number
+  status: ChartPositionStatus
+}
+
+function isFiniteSlot(value: number) {
+  return Number.isFinite(value) && value >= 0
+}
+
+function isFiniteTimeMs(value: number) {
+  return Number.isFinite(value) && value > 0
+}
+
+function toSlotRange(startSlot: number, endSlot: number): SlotRange | null {
+  if (!isFiniteSlot(startSlot) || !isFiniteSlot(endSlot)) return null
+
+  const normalizedStartSlot = Math.floor(Math.min(startSlot, endSlot))
+  const normalizedEndSlot = Math.floor(Math.max(startSlot, endSlot))
+  return {
+    endSlot: normalizedEndSlot,
+    startSlot: normalizedStartSlot,
+  }
+}
+
+export function buildMarketTimeAnchors({
+  candles,
+  chartIntervalMs,
+  events,
+  extraAnchors = [],
+}: {
+  candles: Array<TradingViewAggregatedCandle>
+  chartIntervalMs: number
+  events: Array<MarketUpdateEvent>
+  extraAnchors?: Array<SlotTimeAnchor>
+}) {
+  const anchorsBySlot = new Map<number, SlotTimeAnchor>()
+
+  const addAnchor = ({ slot, timeMs }: SlotTimeAnchor) => {
+    if (!isFiniteSlot(slot) || !isFiniteTimeMs(timeMs)) return
+    anchorsBySlot.set(Math.floor(slot), {
+      slot: Math.floor(slot),
+      timeMs,
+    })
+  }
+
+  for (const candle of candles) {
+    const startTimeMs = candle.time * 1000
+    addAnchor({ slot: candle.startSlot, timeMs: startTimeMs })
+    addAnchor({
+      slot: candle.endSlot,
+      timeMs: startTimeMs + Math.max(0, chartIntervalMs - 1),
+    })
+  }
+
+  for (const event of events) {
+    addAnchor({
+      slot: event.slot,
+      timeMs: new Date(event.created_at).getTime(),
+    })
+  }
+
+  for (const anchor of extraAnchors) {
+    addAnchor(anchor)
+  }
+
+  return Array.from(anchorsBySlot.values()).sort((left, right) => {
+    if (left.slot === right.slot) return left.timeMs - right.timeMs
+    return left.slot - right.slot
+  })
+}
+
+function getSlotDurationMs(
+  left: SlotTimeAnchor,
+  right: SlotTimeAnchor,
+  fallbackSlotDurationMs: number,
+) {
+  const slotDelta = right.slot - left.slot
+  if (slotDelta === 0) return fallbackSlotDurationMs
+
+  const timeDelta = right.timeMs - left.timeMs
+  const duration = timeDelta / slotDelta
+  return Number.isFinite(duration) && duration > 0
+    ? duration
+    : fallbackSlotDurationMs
+}
+
+export function estimateTimeMsForSlot(
+  anchors: Array<SlotTimeAnchor>,
+  slot: number,
+  fallbackSlotDurationMs = SLOT_DURATION_MS,
+) {
+  if (!isFiniteSlot(slot) || anchors.length === 0) return null
+
+  const normalizedSlot = Math.floor(slot)
+  const upperIndex = anchors.findIndex(
+    (anchor) => anchor.slot >= normalizedSlot,
+  )
+
+  if (upperIndex >= 0 && anchors[upperIndex].slot === normalizedSlot) {
+    return anchors[upperIndex].timeMs
+  }
+
+  if (upperIndex < 0) {
+    const last = anchors.at(-1)
+    const previous = anchors.at(-2)
+    if (!last) return null
+
+    const duration =
+      previous === undefined
+        ? fallbackSlotDurationMs
+        : getSlotDurationMs(previous, last, fallbackSlotDurationMs)
+    return last.timeMs + (normalizedSlot - last.slot) * duration
+  }
+
+  const upper = anchors[upperIndex]
+
+  if (upperIndex > 0) {
+    const lower = anchors[upperIndex - 1]
+    const duration = getSlotDurationMs(lower, upper, fallbackSlotDurationMs)
+    return lower.timeMs + (normalizedSlot - lower.slot) * duration
+  }
+
+  const next = anchors.at(upperIndex + 1)
+  const duration =
+    next === undefined
+      ? fallbackSlotDurationMs
+      : getSlotDurationMs(upper, next, fallbackSlotDurationMs)
+  return upper.timeMs - (upper.slot - normalizedSlot) * duration
+}
+
+export function buildChartPositionSlotRanges({
+  activePositions,
+  closedPositions,
+  currentSlot,
+}: {
+  activePositions: Array<TradePositionRecord>
+  closedPositions: Array<ClosePositionEvent>
+  currentSlot: number | null
+}) {
+  const ranges: Array<SlotRange> = []
+
+  for (const position of activePositions) {
+    const startSlot = Number(position.data.startSlot)
+    const positionEndSlot = Number(position.data.endSlot)
+    const endSlot =
+      currentSlot === null
+        ? positionEndSlot
+        : Math.min(Math.max(currentSlot, startSlot), positionEndSlot)
+    const range = toSlotRange(startSlot, endSlot)
+    if (range) ranges.push(range)
+  }
+
+  for (const position of closedPositions) {
+    if (position.start_slot === null || position.end_slot === null) continue
+
+    const lineEndSlot = Math.min(position.end_slot, position.slot)
+    const range = toSlotRange(position.start_slot, lineEndSlot)
+    if (range) ranges.push(range)
+  }
+
+  return mergeAdjacentRanges(ranges, 0)
+}
+
+export function buildChartPositionOverlays({
+  activePositions,
+  anchors,
+  baseDecimals,
+  baseTicker,
+  closedPositions,
+  currentSlot,
+  marketAddress,
+  quoteDecimals,
+  quoteTicker,
+  streamingState,
+}: {
+  activePositions: Array<TradePositionRecord>
+  anchors: Array<SlotTimeAnchor>
+  baseDecimals: number
+  baseTicker: string
+  closedPositions: Array<ClosePositionEvent>
+  currentSlot: number | null
+  marketAddress: Address | undefined
+  quoteDecimals: number
+  quoteTicker: string
+  streamingState: StreamingMarketState | null
+}): Array<ChartPositionOverlay> {
+  const overlays: Array<ChartPositionOverlay> = []
+
+  if (marketAddress && currentSlot !== null) {
+    for (const position of activePositions) {
+      const metrics = getActivePositionMetrics({
+        baseDecimals,
+        baseTicker,
+        endSlotBookkeepingSnapshot: null,
+        market: marketAddress,
+        position: position.data,
+        quoteDecimals,
+        quoteTicker,
+        streamingState,
+      })
+      if (metrics.averagePrice === null) continue
+
+      const startSlot = Number(position.data.startSlot)
+      const positionEndSlot = Number(position.data.endSlot)
+      const lineEndSlot = Math.min(
+        Math.max(currentSlot, startSlot),
+        positionEndSlot,
+      )
+      const startTimeMs = estimateTimeMsForSlot(anchors, startSlot)
+      const endTimeMs = estimateTimeMsForSlot(anchors, lineEndSlot)
+      if (startTimeMs === null || endTimeMs === null) continue
+
+      overlays.push({
+        averagePrice: metrics.averagePrice,
+        endTime: Math.floor(endTimeMs / 1000),
+        id: `active-${position.address}`,
+        label: `${metrics.sideLabel} ${formatAtoms(
+          metrics.amountAtoms,
+          metrics.depositedDecimals,
+        )} ${metrics.depositedToken}`,
+        side: position.data.isBuy === 1 ? 'buy' : 'sell',
+        startTime: Math.floor(startTimeMs / 1000),
+        status: currentSlot < positionEndSlot ? 'active' : 'closed',
+      })
+    }
+  }
+
+  for (const position of closedPositions) {
+    if (position.start_slot === null || position.end_slot === null) continue
+
+    const summary = buildClosedPositionSummary({
+      baseDecimals,
+      baseTicker,
+      event: position,
+      quoteDecimals,
+      quoteTicker,
+    })
+    if (summary.averageFillPrice === null) continue
+
+    const lineEndSlot = Math.min(position.end_slot, position.slot)
+    const startTimeMs = estimateTimeMsForSlot(anchors, position.start_slot)
+    const endTimeMs = estimateTimeMsForSlot(anchors, lineEndSlot)
+    if (startTimeMs === null || endTimeMs === null) continue
+
+    overlays.push({
+      averagePrice: summary.averageFillPrice,
+      endTime: Math.floor(endTimeMs / 1000),
+      id: `closed-${position.id}`,
+      label: `${summary.sideLabel} ${formatAtoms(
+        summary.consumedAtoms,
+        summary.depositDecimals,
+      )} ${summary.depositToken}`,
+      side: summary.isBuy ? 'buy' : 'sell',
+      startTime: Math.floor(startTimeMs / 1000),
+      status: 'closed',
+    })
+  }
+
+  return overlays.sort((left, right) => {
+    if (left.startTime === right.startTime) {
+      return left.averagePrice - right.averagePrice
+    }
+    return left.startTime - right.startTime
+  })
+}

--- a/src/features/trading/queries.ts
+++ b/src/features/trading/queries.ts
@@ -1,6 +1,4 @@
-import type { SolanaClient } from '@solana/client'
 import { queryOptions } from '@tanstack/react-query'
-import type { Address } from '@solana/kit'
 import {
   fetchClosedPositionEvents,
   fetchMarketConfig,
@@ -20,6 +18,8 @@ import {
   resolveSnapshotLocation,
 } from './api/twob-client'
 import { tradingQueryKeys } from './query-keys'
+import type { Address } from '@solana/kit'
+import type { SolanaClient } from '@solana/client'
 
 export const MARKET_UPDATE_RANGE_STALE_TIME = 5 * 60_000
 
@@ -121,10 +121,12 @@ export const tradingQueries = {
       refetchIntervalInBackground: true,
     }),
   closedPositions: ({
+    createdAfter,
     limit = 50,
     marketId,
     positionAuthority,
   }: {
+    createdAfter?: string
     limit?: number
     marketId?: number
     positionAuthority: string
@@ -134,9 +136,15 @@ export const tradingQueries = {
         positionAuthority,
         marketId,
         limit,
+        createdAfter,
       ),
       queryFn: () =>
-        fetchClosedPositionEvents({ limit, marketId, positionAuthority }),
+        fetchClosedPositionEvents({
+          createdAfter,
+          limit,
+          marketId,
+          positionAuthority,
+        }),
     }),
   streamingMarket: ({
     client,

--- a/src/features/trading/query-keys.ts
+++ b/src/features/trading/query-keys.ts
@@ -35,6 +35,7 @@ export const tradingQueryKeys = {
     authority: string | null | undefined,
     marketId: number | undefined,
     limit: number,
+    createdAfter?: string,
   ) =>
     [
       'trading',
@@ -42,6 +43,7 @@ export const tradingQueryKeys = {
       normalizeKeyPart(authority),
       normalizeKeyPart(marketId),
       limit,
+      normalizeKeyPart(createdAfter),
     ] as const,
   streamingMarket: (marketAddress: string | null | undefined) =>
     ['trading', 'streaming-market', normalizeKeyPart(marketAddress)] as const,


### PR DESCRIPTION
## Summary
- Show connected wallet active and closed positions on the price chart with buy/sell badges including size.
- Draw average-fill-price interval lines from start slot to end/current slot, with active lines updating from streamed state.
- Fetch closed wallet positions from the last 30 days and approximate slot timestamps from market update anchors, candles, and live slot data.
- Stack overlapping chart badges and share the overlay across desktop and mobile chart surfaces.

## Validation
- pnpm exec eslint src/features/trading/api/market-repository.ts src/features/trading/query-keys.ts src/features/trading/queries.ts src/features/trading/hooks/use-closed-position-events.ts src/features/trading/lib/chart-positions.ts src/features/trading/lib/chart-positions.test.ts src/features/trading/components/market-price-chart.tsx src/features/trading/components/trading-dashboard.tsx
- pnpm test
- pnpm build
- git diff --check

## Browser Smoke
- Not run: the required in-app Browser JavaScript bridge was not exposed in this session after tool discovery.

## Notes
- Closed-position overlays are limited to positions with created_at in the last 30 days.
- Missing position slot timestamps are approximated from surrounding market_update_events; candles and live slot data are used as fallback anchors.

Linear: https://linear.app/nachtschatten-labs/issue/NAC-30/show-positions-in-price-chart