### PR TITLE
fix: refresh closed position chart after close

### DIFF
--- a/src/features/trading/hooks/use-close-position.ts
+++ b/src/features/trading/hooks/use-close-position.ts
@@ -9,6 +9,9 @@ import { sendClosePosition, sendClosePositions } from '../api/twob-client'
 import { formatTransactionError } from '../lib/transaction-errors'
 import { tradingQueryKeys } from '../query-keys'
 import type { Address } from '@solana/kit'
+import type { QueryClient } from '@tanstack/react-query'
+
+const CLOSED_POSITION_REFRESH_DELAYS_MS = [1_500, 5_000, 10_000]
 
 type ClosePositionStatus =
   | 'idle'
@@ -16,6 +19,29 @@ type ClosePositionStatus =
   | 'submitting'
   | 'success'
   | 'error'
+
+function invalidateClosedPositionQueries({
+  authority,
+  queryClient,
+}: {
+  authority: string
+  queryClient: QueryClient
+}) {
+  const queryKey = tradingQueryKeys.closedPositionsForAuthority(authority)
+  const invalidate = () =>
+    queryClient.invalidateQueries({
+      queryKey,
+    })
+
+  const immediateInvalidation = invalidate()
+  for (const delayMs of CLOSED_POSITION_REFRESH_DELAYS_MS) {
+    window.setTimeout(() => {
+      void invalidate()
+    }, delayMs)
+  }
+
+  return immediateInvalidation
+}
 
 export function useClosePosition() {
   const client = useSolanaClient()
@@ -70,12 +96,9 @@ export function useClosePosition() {
           queryClient.invalidateQueries({
             queryKey: tradingQueryKeys.tradePositions(connectedAddress),
           }),
-          queryClient.invalidateQueries({
-            queryKey: tradingQueryKeys.closedPositions(
-              connectedAddress,
-              undefined,
-              50,
-            ),
+          invalidateClosedPositionQueries({
+            authority: connectedAddress,
+            queryClient,
           }),
           queryClient.invalidateQueries({
             queryKey: tradingQueryKeys.ownedExitsAccounts(connectedAddress),
@@ -145,12 +168,9 @@ export function useClosePosition() {
           queryClient.invalidateQueries({
             queryKey: tradingQueryKeys.tradePositions(connectedAddress),
           }),
-          queryClient.invalidateQueries({
-            queryKey: tradingQueryKeys.closedPositions(
-              connectedAddress,
-              undefined,
-              50,
-            ),
+          invalidateClosedPositionQueries({
+            authority: connectedAddress,
+            queryClient,
           }),
           queryClient.invalidateQueries({
             queryKey: tradingQueryKeys.ownedExitsAccounts(connectedAddress),

--- a/src/features/trading/query-keys.test.ts
+++ b/src/features/trading/query-keys.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { tradingQueryKeys } from './query-keys'
+
+describe('tradingQueryKeys.closedPositionsForAuthority', () => {
+  it('matches every closed-position query variant for the wallet', () => {
+    const authority = 'wallet-address'
+    const prefix = tradingQueryKeys.closedPositionsForAuthority(authority)
+    const chartQueryKey = tradingQueryKeys.closedPositions(
+      authority,
+      1,
+      1000,
+      '2026-06-05T12:00:00.000Z',
+    )
+    const listQueryKey = tradingQueryKeys.closedPositions(
+      authority,
+      undefined,
+      50,
+    )
+
+    expect(chartQueryKey.slice(0, prefix.length)).toEqual(prefix)
+    expect(listQueryKey.slice(0, prefix.length)).toEqual(prefix)
+  })
+})

--- a/src/features/trading/query-keys.ts
+++ b/src/features/trading/query-keys.ts
@@ -45,6 +45,8 @@ export const tradingQueryKeys = {
       limit,
       normalizeKeyPart(createdAfter),
     ] as const,
+  closedPositionsForAuthority: (authority: string | null | undefined) =>
+    ['trading', 'closed-positions', normalizeKeyPart(authority)] as const,
   streamingMarket: (marketAddress: string | null | undefined) =>
     ['trading', 'streaming-market', normalizeKeyPart(marketAddress)] as const,
   endSlotSnapshot: (


### PR DESCRIPTION
Fixes NAC-30 follow-up bug where closing a position removed the active chart overlay but did not refresh the chart's closed-position query variant.

## Summary
- Add a wallet-scoped closed-position query key prefix.
- Invalidate all closed-position query variants after single and batch close transactions.
- Repeat the invalidation briefly after confirmation to cover close-event indexer lag.
- Add a regression test proving the chart/list closed-position keys share the wallet prefix.

## Validation
- `pnpm exec eslint src/features/trading/hooks/use-close-position.ts src/features/trading/query-keys.ts src/features/trading/query-keys.test.ts`
- `pnpm exec vitest run src/features/trading/query-keys.test.ts src/features/trading/lib/chart-positions.test.ts`
- `pnpm test`
- `pnpm build`
- `git diff --check`