### PR TITLE
fix: allow mobile chart price scale dragging

### DIFF
--- a/src/features/trading/components/market-price-chart.tsx
+++ b/src/features/trading/components/market-price-chart.tsx
@@ -644,7 +644,9 @@ export function MarketPriceChart({
         horzTouchDrag: true,
         mouseWheel: true,
         pressedMouseMove: true,
-        vertTouchDrag: false,
+        // lightweight-charts only forwards touch moves on the price axis when
+        // vertical touch drag is allowed.
+        vertTouchDrag: true,
       },
       handleScale: {
         axisPressedMouseMove: true,
@@ -975,7 +977,7 @@ export function MarketPriceChart({
   }, [chartData, positionOverlays])
 
   return (
-    <div className="relative h-full min-h-[420px] w-full">
+    <div className="relative h-full min-h-[420px] w-full touch-none">
       <div ref={containerRef} className="h-full min-h-[420px] w-full" />
       {projectedPositionOverlays.length > 0 ? (
         <div className="pointer-events-none absolute inset-0 overflow-hidden">


### PR DESCRIPTION
## Summary
- enable vertical touch drag handling so lightweight-charts forwards touch moves on the price axis
- add a touch-action boundary on the chart host so drawer/browser scrolling does not steal the axis drag gesture

## Validation
- `pnpm exec prettier --write src/features/trading/components/market-price-chart.tsx`
- `pnpm exec eslint src/features/trading/components/market-price-chart.tsx`
- `pnpm test`
- `pnpm build`
- `git diff --check`

Linear: NAC-32