### PR TITLE
fix: isolate chart touches from drawer swipe

### DIFF
--- a/src/features/trading/components/market-price-chart.tsx
+++ b/src/features/trading/components/market-price-chart.tsx
@@ -977,7 +977,10 @@ export function MarketPriceChart({
   }, [chartData, positionOverlays])
 
   return (
-    <div className="relative h-full min-h-[420px] w-full touch-none">
+    <div
+      className="relative h-full min-h-[420px] w-full touch-none"
+      data-base-ui-swipe-ignore=""
+    >
       <div ref={containerRef} className="h-full min-h-[420px] w-full" />
       {projectedPositionOverlays.length > 0 ? (
         <div className="pointer-events-none absolute inset-0 overflow-hidden">


### PR DESCRIPTION
## Summary
- mark the chart host with Base UI's `data-base-ui-swipe-ignore` attribute
- prevents drawer swipe-dismiss tracking from starting when touch gestures begin on the chart or price axis
- keeps the NAC-32 chart touch scaling behavior while avoiding drawer pull-down during chart interaction

## Validation
- `pnpm exec prettier --write src/features/trading/components/market-price-chart.tsx`
- `pnpm exec eslint src/features/trading/components/market-price-chart.tsx`
- `pnpm test`
- `pnpm build`
- `git diff --check`

Linear: NAC-32