### PR TITLE
fix: refresh wallet discovery

### DIFF
--- a/src/integrations/solana/index.ts
+++ b/src/integrations/solana/index.ts
@@ -1,2 +1,2 @@
 export { rpc, rpcSubscriptions, endpoint, websocketEndpoint } from './client'
-export { SolanaProvider, solanaClient } from './provider'
+export { SolanaProvider } from './provider'

--- a/src/integrations/solana/provider.test.tsx
+++ b/src/integrations/solana/provider.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SolanaProvider } from './provider'
+import type { WalletConnector } from '@solana/client'
+
+const mocks = vi.hoisted(() => {
+  const clients: Array<any> = []
+
+  return {
+    clients,
+    createClient: vi.fn((config: { walletConnectors: Array<any> }) => {
+      const client: any = {
+        connectors: {
+          all: config.walletConnectors,
+          get: (id: string) =>
+            config.walletConnectors.find((connector) => connector.id === id),
+        },
+        destroy: vi.fn(),
+        store: {
+          getState: vi.fn(() => ({
+            wallet: client.wallet,
+          })),
+          setState: vi.fn((updater) => {
+            const state = { lastUpdatedAt: 0, wallet: client.wallet }
+            const nextState =
+              typeof updater === 'function' ? updater(state) : updater
+            client.wallet = nextState.wallet
+          }),
+        },
+        wallet: {
+          status: 'disconnected',
+        },
+      }
+
+      clients.push(client)
+      return client
+    }),
+    initialConnectors: [] as Array<any>,
+    unwatch: vi.fn(),
+    watcher: null as ((connectors: Array<any>) => void) | null,
+  }
+})
+
+vi.mock('@solana/client', () => ({
+  createClient: mocks.createClient,
+  getWalletStandardConnectors: vi.fn(() => mocks.initialConnectors),
+  watchWalletStandardConnectors: vi.fn((onChange) => {
+    mocks.watcher = onChange
+    onChange(mocks.initialConnectors)
+    return mocks.unwatch
+  }),
+}))
+
+vi.mock('@solana/react-hooks', async () => {
+  const React = await import('react')
+
+  return {
+    SolanaProvider: ({
+      children,
+      client,
+    }: {
+      children: React.ReactNode
+      client: any
+    }) =>
+      React.createElement(
+        'div',
+        {
+          'data-testid': 'solana-provider',
+          'data-wallet-connectors': client.connectors.all
+            .map((connector: WalletConnector) => connector.name)
+            .join(','),
+        },
+        children,
+      ),
+  }
+})
+
+function createConnector(name: string): WalletConnector {
+  return {
+    canAutoConnect: true,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    id: `wallet-standard:${name.toLowerCase()}`,
+    isSupported: () => true,
+    name,
+    ready: true,
+  } as unknown as WalletConnector
+}
+
+describe('SolanaProvider', () => {
+  beforeEach(() => {
+    mocks.clients.length = 0
+    mocks.initialConnectors.length = 0
+    mocks.watcher = null
+    vi.clearAllMocks()
+  })
+
+  it('refreshes the client registry when wallets register after mount', async () => {
+    const phantom = createConnector('Phantom')
+    const solflare = createConnector('Solflare')
+    mocks.initialConnectors.push(phantom)
+
+    render(
+      <SolanaProvider>
+        <span>child</span>
+      </SolanaProvider>,
+    )
+
+    expect(
+      screen
+        .getByTestId('solana-provider')
+        .getAttribute('data-wallet-connectors'),
+    ).toBe('Phantom')
+    await waitFor(() => expect(mocks.watcher).toBeTruthy())
+
+    act(() => {
+      mocks.watcher?.([phantom, solflare])
+    })
+
+    expect(
+      screen
+        .getByTestId('solana-provider')
+        .getAttribute('data-wallet-connectors'),
+    ).toBe('Phantom,Solflare')
+    expect(mocks.clients).toHaveLength(2)
+    expect(mocks.clients[0].destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves an active wallet session when rebuilding the client', async () => {
+    const phantom = createConnector('Phantom')
+    const solflare = createConnector('Solflare')
+    const wallet = {
+      connectorId: phantom.id,
+      session: {
+        account: {
+          address: '11111111111111111111111111111111',
+          publicKey: new Uint8Array(),
+        },
+        disconnect: vi.fn(),
+      },
+      status: 'connected',
+    }
+    mocks.initialConnectors.push(phantom)
+
+    render(
+      <SolanaProvider>
+        <span>child</span>
+      </SolanaProvider>,
+    )
+    await waitFor(() => expect(mocks.watcher).toBeTruthy())
+    mocks.clients[0].wallet = wallet
+
+    act(() => {
+      mocks.watcher?.([phantom, solflare])
+    })
+
+    expect(mocks.clients[1].store.setState).toHaveBeenCalledTimes(1)
+    expect(mocks.clients[1].wallet).toBe(wallet)
+  })
+})

--- a/src/integrations/solana/provider.tsx
+++ b/src/integrations/solana/provider.tsx
@@ -1,5 +1,11 @@
+import { useEffect, useRef, useState } from 'react'
 import { SolanaProvider as BaseSolanaProvider } from '@solana/react-hooks'
-import { autoDiscover, createClient } from '@solana/client'
+import {
+  createClient,
+  getWalletStandardConnectors,
+  watchWalletStandardConnectors,
+} from '@solana/client'
+import type { SolanaClient, WalletConnector } from '@solana/client'
 
 const endpoint =
   (typeof window !== 'undefined' && import.meta.env.VITE_SOLANA_RPC_URL) ||
@@ -9,15 +15,78 @@ const websocketEndpoint =
   (typeof window !== 'undefined' && import.meta.env.VITE_SOLANA_WS_URL) ||
   endpoint.replace('https://', 'wss://').replace('http://', 'ws://')
 
-export const solanaClient = createClient({
-  endpoint,
-  websocketEndpoint,
-  walletConnectors: autoDiscover(),
-})
+function getInitialWalletConnectors() {
+  if (typeof window === 'undefined') return []
 
-export function SolanaProvider({ children }: { children: React.ReactNode }) {
+  return getWalletStandardConnectors()
+}
+
+function haveSameConnectors(
+  previous: ReadonlyArray<WalletConnector>,
+  next: ReadonlyArray<WalletConnector>,
+) {
   return (
-    <BaseSolanaProvider client={solanaClient}>{children}</BaseSolanaProvider>
+    previous.length === next.length &&
+    previous.every(
+      (connector, index) =>
+        connector.id === next[index]?.id &&
+        connector.name === next[index]?.name,
+    )
   )
 }
- 
+
+function createSolanaClient(
+  walletConnectors: ReadonlyArray<WalletConnector>,
+  previousClient?: SolanaClient,
+) {
+  const client = createClient({
+    endpoint,
+    websocketEndpoint,
+    walletConnectors,
+  })
+
+  const previousWallet = previousClient?.store.getState().wallet
+  if (previousWallet && previousWallet.status !== 'disconnected') {
+    client.store.setState((state) => ({
+      ...state,
+      lastUpdatedAt: Date.now(),
+      wallet: previousWallet,
+    }))
+  }
+
+  return client
+}
+
+export function SolanaProvider({ children }: { children: React.ReactNode }) {
+  const [client, setClient] = useState(() =>
+    createSolanaClient(getInitialWalletConnectors()),
+  )
+  const clientRef = useRef(client)
+
+  useEffect(() => {
+    clientRef.current = client
+  }, [client])
+
+  useEffect(() => {
+    const unwatch = watchWalletStandardConnectors((walletConnectors) => {
+      setClient((previousClient) => {
+        if (
+          haveSameConnectors(previousClient.connectors.all, walletConnectors)
+        ) {
+          return previousClient
+        }
+
+        const nextClient = createSolanaClient(walletConnectors, previousClient)
+        previousClient.destroy()
+        return nextClient
+      })
+    })
+
+    return () => {
+      unwatch()
+      clientRef.current.destroy()
+    }
+  }, [])
+
+  return <BaseSolanaProvider client={client}>{children}</BaseSolanaProvider>
+}


### PR DESCRIPTION
## Summary

- Refresh the Solana client wallet registry when Wallet Standard wallets register or unregister after app startup.
- Preserve an active wallet session when rebuilding the client so a late wallet registration does not disconnect the current wallet.
- Add provider coverage for late Solflare-style registration and active-session preservation.

## Root Cause

The app created one module-level Solana client with `autoDiscover()`, which only captures Wallet Standard wallets that are already registered at that moment. If Solflare registered after that snapshot, `useWalletConnection()` and `connect()` kept using the stale client registry until a full page refresh.

## Validation

- `pnpm test`
- `pnpm exec eslint src/integrations/solana/provider.tsx src/integrations/solana/provider.test.tsx src/integrations/solana/index.ts`
- `pnpm build`

Note: full `pnpm lint` is currently blocked by unrelated baseline lint issues across existing/generated files.