### PR TITLE
[codex] Fix empty page scroll

### DIFF
--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -705,7 +705,7 @@ export function TradingDashboard() {
   }
 
   return (
-    <div className="relative min-h-screen bg-[color:var(--color-page-bg)] text-foreground">
+    <div className="relative min-h-[calc(100dvh-3.5rem)] bg-[color:var(--color-page-bg)] text-foreground">
       <div className="relative mx-auto max-w-[1440px] px-4 pb-12 pt-5 sm:px-6 lg:px-8">
         <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
           <div className="flex min-w-0 items-baseline gap-3">

--- a/src/routes/rent.tsx
+++ b/src/routes/rent.tsx
@@ -76,7 +76,7 @@ function RentPage() {
     ownerAddress !== null && (pricesQuery.isFetching || exitsQuery.isFetching)
 
   return (
-    <div className="relative min-h-screen bg-[color:var(--color-page-bg)] text-foreground">
+    <div className="relative min-h-[calc(100dvh-3.5rem)] bg-[color:var(--color-page-bg)] text-foreground">
       <div className="relative mx-auto max-w-[1440px] px-4 pb-12 pt-5 sm:px-6 lg:px-8">
         <div className="mb-4 flex flex-wrap items-center gap-3">
           <h1 className="text-2xl font-semibold tracking-[-0.04em]">

--- a/src/styles.css
+++ b/src/styles.css
@@ -111,6 +111,7 @@
 
   html {
     color-scheme: dark;
+    overscroll-behavior-y: none;
   }
 
   body {


### PR DESCRIPTION
## Summary

- Change the trade dashboard page wrapper to account for the sticky 56px navbar in its minimum viewport height.
- Apply the same page-height fix to the rent accounts route.
- Disable vertical page overscroll bounce so scrolling past the top or bottom does not drag the page.

## Why

The page body could remain scrollable even when there was no content below the visible UI. The page wrappers used `min-h-screen` below a sticky `h-14` navbar, which made the document at least one full viewport plus the navbar height.

The browser also allowed root-level overscroll at the page boundaries, creating the rubber-band drag effect when scrolling beyond the top or bottom.

## Validation

- `pnpm run build`
- `pnpm exec eslint src/features/trading/components/trading-dashboard.tsx`
- `pnpm exec eslint src/styles.css` (CSS file is ignored by the current ESLint config; no errors)

Note: targeted lint including `src/routes/rent.tsx` still reports pre-existing style issues in that file unrelated to this change: import ordering and array type syntax.