### PR TITLE
feat: show 24h market price change

### DIFF
--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -44,6 +44,7 @@ import { useMarketAddress } from '../hooks/use-market-address'
 import { useMarketChartHistory } from '../hooks/use-market-chart-history'
 import { useMarketConfig } from '../hooks/use-market-config'
 import { useMarketPrice } from '../hooks/use-market-price'
+import { useMarketPriceChange24h } from '../hooks/use-market-price-change'
 import { useMarketUpdates } from '../hooks/use-market-updates'
 import { useStreamingMarketState } from '../hooks/use-streaming-market-state'
 import { useTradePositions } from '../hooks/use-trade-positions'
@@ -82,6 +83,7 @@ import type { TradePositionRecord } from '../domain/models'
 import type { TradingViewAggregatedCandle } from '../lib/market'
 import { endpoint } from '@/integrations/solana'
 import { Alert } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import {
@@ -116,6 +118,7 @@ export function TradingDashboard() {
   const marketConfigQuery = useMarketConfig(MARKET_ID)
   const marketConfig = marketConfigQuery.data ?? null
   const marketPriceQuery = useMarketPrice(MARKET_ID)
+  const marketPriceChange24hQuery = useMarketPriceChange24h(MARKET_ID)
   const marketUpdates = useMarketUpdates({
     limit: DEFAULT_MARKET_UPDATES_LIMIT,
     marketId: MARKET_ID,
@@ -377,6 +380,7 @@ export function TradingDashboard() {
         durationSeconds,
         marketPrice: marketPriceQuery.data,
         marketUpdates: marketUpdates.events,
+        priceChangeHistory: marketPriceChange24hQuery.data ?? [],
         quoteDecimals,
         quoteTicker,
         side,
@@ -393,6 +397,7 @@ export function TradingDashboard() {
       durationSeconds,
       marketChartHistory.candles,
       marketPriceQuery.data,
+      marketPriceChange24hQuery.data,
       marketUpdates.events,
       quoteDecimals,
       quoteTicker,
@@ -407,6 +412,8 @@ export function TradingDashboard() {
     executionPriceDisplay,
     priceImpactPercent,
     priceImpactDisplay,
+    priceChange24hDisplay,
+    priceChange24hPercent,
   } = dashboardViewModel
   const hasHighPriceImpact = isHighPriceImpact(priceImpactPercent)
   const highPriceImpactThresholdDisplay = `${HIGH_PRICE_IMPACT_WARNING_THRESHOLD_PERCENT}%`
@@ -708,13 +715,17 @@ export function TradingDashboard() {
     <div className="relative min-h-[calc(100dvh-3.5rem)] bg-[color:var(--color-page-bg)] text-foreground">
       <div className="relative mx-auto max-w-[1440px] px-4 pb-12 pt-5 sm:px-6 lg:px-8">
         <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
-          <div className="flex min-w-0 items-baseline gap-3">
+          <div className="flex min-w-0 items-center gap-3">
             <h1 className="text-xl font-semibold tracking-[-0.04em] sm:text-2xl">
               {baseTicker}/{quoteTicker}
             </h1>
             <span className="text-xl font-semibold tracking-[-0.04em] text-[color:var(--color-accent-strong)] sm:text-2xl">
               {formatDashboardPrice(displayPrice)}
             </span>
+            <PriceChangeBadge
+              display={priceChange24hDisplay}
+              value={priceChange24hPercent}
+            />
           </div>
           <Drawer>
             <DrawerTrigger
@@ -735,7 +746,13 @@ export function TradingDashboard() {
                   {baseTicker}/{quoteTicker}
                 </DrawerTitle>
                 <DrawerDescription>
-                  {formatDashboardPrice(displayPrice)}
+                  <span className="flex flex-wrap items-center gap-2">
+                    <span>{formatDashboardPrice(displayPrice)}</span>
+                    <PriceChangeBadge
+                      display={priceChange24hDisplay}
+                      value={priceChange24hPercent}
+                    />
+                  </span>
                 </DrawerDescription>
               </DrawerHeader>
               <PriceChartPanel
@@ -1006,6 +1023,27 @@ function EmptyState({ copy }: { copy: string }) {
         {copy}
       </CardContent>
     </Card>
+  )
+}
+
+function PriceChangeBadge({
+  display,
+  value,
+}: {
+  display: string
+  value: number | null
+}) {
+  const variant =
+    value === null || value === 0
+      ? 'muted'
+      : value > 0
+        ? 'positive'
+        : 'negative'
+
+  return (
+    <Badge className="normal-case tracking-normal" variant={variant}>
+      {display}
+    </Badge>
   )
 }
 

--- a/src/features/trading/hooks/use-market-price-change.ts
+++ b/src/features/trading/hooks/use-market-price-change.ts
@@ -1,0 +1,6 @@
+import { useQuery } from '@tanstack/react-query'
+import { tradingQueries } from '../queries'
+
+export function useMarketPriceChange24h(marketId: number) {
+  return useQuery(tradingQueries.marketPriceChange24h(marketId))
+}

--- a/src/features/trading/queries.ts
+++ b/src/features/trading/queries.ts
@@ -1,6 +1,7 @@
 import { queryOptions } from '@tanstack/react-query'
 import {
   fetchClosedPositionEvents,
+  fetchMarketCandles,
   fetchMarketConfig,
   fetchMarketPrice,
   fetchMarketUpdateRange,
@@ -22,6 +23,9 @@ import type { Address } from '@solana/kit'
 import type { SolanaClient } from '@solana/client'
 
 export const MARKET_UPDATE_RANGE_STALE_TIME = 5 * 60_000
+const MARKET_PRICE_CHANGE_24H_INTERVAL = '5m'
+const MARKET_PRICE_CHANGE_24H_WINDOW_MS = 25 * 60 * 60_000
+const MARKET_PRICE_CHANGE_24H_MAX_POINTS = 320
 
 export const tradingQueries = {
   marketAddress: (marketId: number) =>
@@ -73,6 +77,23 @@ export const tradingQueries = {
       queryFn: async () => fetchMarketPrice({ marketId }),
       refetchInterval: 5_000,
       refetchIntervalInBackground: true,
+    }),
+  marketPriceChange24h: (marketId: number) =>
+    queryOptions({
+      queryKey: tradingQueryKeys.marketPriceChange24h(marketId),
+      queryFn: async () => {
+        const now = Date.now()
+        return fetchMarketCandles({
+          from: new Date(now - MARKET_PRICE_CHANGE_24H_WINDOW_MS),
+          interval: MARKET_PRICE_CHANGE_24H_INTERVAL,
+          marketId,
+          maxPoints: MARKET_PRICE_CHANGE_24H_MAX_POINTS,
+          to: new Date(now + 5 * 60_000),
+        })
+      },
+      refetchInterval: 60_000,
+      refetchIntervalInBackground: true,
+      staleTime: 60_000,
     }),
   tradePositions: ({
     authority,

--- a/src/features/trading/query-keys.ts
+++ b/src/features/trading/query-keys.ts
@@ -25,6 +25,8 @@ export const tradingQueryKeys = {
     ] as const,
   marketPrice: (marketId: number) =>
     ['trading', 'market-price', marketId] as const,
+  marketPriceChange24h: (marketId: number) =>
+    ['trading', 'market-price-change-24h', marketId] as const,
   tradePositions: (authority: string | null | undefined) =>
     ['trading', 'trade-positions', normalizeKeyPart(authority)] as const,
   ownedPricesAccounts: (authority: string | null | undefined) =>

--- a/src/features/trading/view-models/trading-dashboard.test.ts
+++ b/src/features/trading/view-models/trading-dashboard.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildTradingDashboardViewModel,
+  calculateRelativePriceChangePercent,
   deriveMarketIdentity,
+  formatDashboardPriceChangePercent,
 } from './trading-dashboard'
 import type { TradingViewAggregatedCandle } from '../lib/market'
 
@@ -47,7 +49,7 @@ describe('buildTradingDashboardViewModel', () => {
       chartCandles,
       crosshairData: null,
       durationSeconds: 60,
-      marketPrice: { price: 20, slot: 11 },
+      marketPrice: { eventTimeMs: 1_742_428_800_000, price: 20, slot: 11 },
       marketUpdates: [
         {
           base_flow: 1_000_000_000n,
@@ -68,6 +70,18 @@ describe('buildTradingDashboardViewModel', () => {
           slot: 10,
         },
       ],
+      priceChangeHistory: [
+        {
+          close: 16,
+          endSlot: 1,
+          high: 16,
+          low: 16,
+          open: 16,
+          startSlot: 1,
+          time: 1_742_342_400,
+          volume: 10,
+        },
+      ],
       quoteDecimals: 9,
       quoteTicker: 'USDC',
       side: 'buy',
@@ -85,7 +99,74 @@ describe('buildTradingDashboardViewModel', () => {
 
     expect(viewModel.displayPrice).toBe(20)
     expect(viewModel.priceDelta).toBe(1)
+    expect(viewModel.priceChange24hPercent).toBe(25)
+    expect(viewModel.priceChange24hDisplay).toBe('+25.00% 24h')
     expect(viewModel.estimatedConversionText).toContain('SOL')
     expect(viewModel.executionPriceDisplay).toMatch(/^\$/)
+  })
+})
+
+describe('calculateRelativePriceChangePercent', () => {
+  it('compares current price to the latest candle at or before 24h ago', () => {
+    const referenceTime = 1_742_428_800
+    const priceHistory: Array<TradingViewAggregatedCandle> = [
+      {
+        close: 98,
+        endSlot: 1,
+        high: 98,
+        low: 98,
+        open: 98,
+        startSlot: 1,
+        time: referenceTime - 24 * 60 * 60 - 300,
+        volume: 1,
+      },
+      {
+        close: 100,
+        endSlot: 2,
+        high: 100,
+        low: 100,
+        open: 100,
+        startSlot: 2,
+        time: referenceTime - 24 * 60 * 60,
+        volume: 1,
+      },
+      {
+        close: 102,
+        endSlot: 3,
+        high: 102,
+        low: 102,
+        open: 102,
+        startSlot: 3,
+        time: referenceTime - 24 * 60 * 60 + 300,
+        volume: 1,
+      },
+    ]
+
+    expect(
+      calculateRelativePriceChangePercent({
+        currentPrice: 110,
+        priceHistory,
+        referenceTime,
+      }),
+    ).toBe(10)
+  })
+
+  it('returns null without a valid 24h reference price', () => {
+    expect(
+      calculateRelativePriceChangePercent({
+        currentPrice: 110,
+        priceHistory: [],
+        referenceTime: 1_742_428_800,
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('formatDashboardPriceChangePercent', () => {
+  it('formats signed 24h percentages', () => {
+    expect(formatDashboardPriceChangePercent(1.234)).toBe('+1.23% 24h')
+    expect(formatDashboardPriceChangePercent(-0.004)).toBe('-<0.01% 24h')
+    expect(formatDashboardPriceChangePercent(0)).toBe('0.00% 24h')
+    expect(formatDashboardPriceChangePercent(null)).toBe('24h —')
   })
 })

--- a/src/features/trading/view-models/trading-dashboard.ts
+++ b/src/features/trading/view-models/trading-dashboard.ts
@@ -17,6 +17,8 @@ import type {
   TradePositionRecord,
 } from '../domain/models'
 
+const PRICE_CHANGE_24H_LOOKBACK_SECONDS = 24 * 60 * 60
+
 export interface DashboardChartFocus {
   close: number
   high: number
@@ -46,6 +48,57 @@ function resolveTicker(
   )
 }
 
+function findPriceAtOrBefore(
+  candles: Array<TradingViewAggregatedCandle>,
+  targetTime: number,
+) {
+  let candidate: TradingViewAggregatedCandle | null = null
+
+  for (const candle of candles) {
+    if (candle.time > targetTime) {
+      break
+    }
+    candidate = candle
+  }
+
+  return candidate?.close ?? null
+}
+
+export function calculateRelativePriceChangePercent({
+  currentPrice,
+  priceHistory,
+  referenceTime,
+}: {
+  currentPrice: number | null
+  priceHistory: Array<TradingViewAggregatedCandle>
+  referenceTime: number | null
+}) {
+  if (
+    currentPrice === null ||
+    referenceTime === null ||
+    !Number.isFinite(currentPrice) ||
+    !Number.isFinite(referenceTime) ||
+    currentPrice <= 0
+  ) {
+    return null
+  }
+
+  const referencePrice = findPriceAtOrBefore(
+    priceHistory,
+    referenceTime - PRICE_CHANGE_24H_LOOKBACK_SECONDS,
+  )
+
+  if (
+    referencePrice === null ||
+    !Number.isFinite(referencePrice) ||
+    referencePrice <= 0
+  ) {
+    return null
+  }
+
+  return ((currentPrice - referencePrice) / referencePrice) * 100
+}
+
 export function deriveMarketIdentity(
   marketConfig: MarketConfigRow | null | undefined,
 ): TradingMarketIdentity {
@@ -72,6 +125,7 @@ export function buildTradingDashboardViewModel({
   durationSeconds,
   marketPrice,
   marketUpdates,
+  priceChangeHistory,
   quoteDecimals,
   quoteTicker,
   side,
@@ -85,8 +139,13 @@ export function buildTradingDashboardViewModel({
   chartCandles: Array<TradingViewAggregatedCandle>
   crosshairData: DashboardChartFocus | null
   durationSeconds: number
-  marketPrice?: { price: number | null; slot: number | null }
+  marketPrice?: {
+    eventTimeMs?: number | null
+    price: number | null
+    slot: number | null
+  }
   marketUpdates: Array<MarketUpdateEvent>
+  priceChangeHistory: Array<TradingViewAggregatedCandle>
   quoteDecimals: number
   quoteTicker: string
   side: OrderSide
@@ -135,6 +194,16 @@ export function buildTradingDashboardViewModel({
     priceDelta !== null && displayPrice !== null && displayPrice > 0
       ? (priceDelta / displayPrice) * 100
       : null
+  const priceChangeReferenceTime =
+    typeof marketPrice?.eventTimeMs === 'number' &&
+    Number.isFinite(marketPrice.eventTimeMs)
+      ? Math.floor(marketPrice.eventTimeMs / 1000)
+      : (priceChangeHistory.at(-1)?.time ?? latestChartCandle?.time ?? null)
+  const priceChange24hPercent = calculateRelativePriceChangePercent({
+    currentPrice: displayPrice,
+    priceHistory: priceChangeHistory,
+    referenceTime: priceChangeReferenceTime,
+  })
 
   const marketStats = computeMarketStats(
     marketUpdates,
@@ -215,6 +284,10 @@ export function buildTradingDashboardViewModel({
     onChainIndicativePrice,
     priceDelta,
     priceDeltaPercent,
+    priceChange24hDisplay: formatDashboardPriceChangePercent(
+      priceChange24hPercent,
+    ),
+    priceChange24hPercent,
     priceImpactDisplay:
       priceImpactPercent === null
         ? '0%'
@@ -226,4 +299,14 @@ export function buildTradingDashboardViewModel({
 
 export function formatDashboardPrice(value: number | null) {
   return value === null ? '—' : `$${formatPrice(value)}`
+}
+
+export function formatDashboardPriceChangePercent(value: number | null) {
+  if (value === null || !Number.isFinite(value)) return '24h —'
+
+  const absolute = Math.abs(value)
+  const formatted =
+    absolute > 0 && absolute < 0.01 ? '<0.01' : absolute.toFixed(2)
+  const sign = value > 0 ? '+' : value < 0 ? '-' : ''
+  return `${sign}${formatted}% 24h`
 }


### PR DESCRIPTION
## Summary
- add a 24h market price change query backed by 5m candle history
- calculate and format the relative change versus the price 24h ago in the trading dashboard view model
- show a positive/negative/muted 24h badge next to the current market price in the desktop header and mobile chart drawer header

## Validation
- `pnpm exec prettier --write src/features/trading/query-keys.ts src/features/trading/queries.ts src/features/trading/hooks/use-market-price-change.ts src/features/trading/view-models/trading-dashboard.ts src/features/trading/view-models/trading-dashboard.test.ts src/features/trading/components/trading-dashboard.tsx`
- `pnpm exec eslint src/features/trading/query-keys.ts src/features/trading/queries.ts src/features/trading/hooks/use-market-price-change.ts src/features/trading/view-models/trading-dashboard.ts src/features/trading/view-models/trading-dashboard.test.ts src/features/trading/components/trading-dashboard.tsx`
- `pnpm test`
- `pnpm build`
- `git diff --check`

Note: attempted local browser smoke via `pnpm run dev`, but the dev server did not bind to port 3000 before it was stopped.

Linear: NAC-33