### PR TITLE
NAC-34: Show active order book

### DIFF
--- a/src/features/trading/api/twob-client.ts
+++ b/src/features/trading/api/twob-client.ts
@@ -312,6 +312,21 @@ export async function fetchTradePositions(
   rpcClient: TwobRpcClient,
   authority: string,
 ): Promise<Array<TradePositionRecord>> {
+  return fetchTradePositionAccounts(rpcClient, [
+    {
+      memcmp: {
+        bytes: authority as never,
+        encoding: 'base58',
+        offset: 8n,
+      },
+    },
+  ])
+}
+
+async function fetchTradePositionAccounts(
+  rpcClient: TwobRpcClient,
+  extraFilters: Array<unknown> = [],
+): Promise<Array<TradePositionRecord>> {
   const response = (await rpcClient
     .getProgramAccounts(TWOB_ANCHOR_PROGRAM_ADDRESS, {
       commitment: 'confirmed',
@@ -326,13 +341,7 @@ export async function fetchTradePositions(
             offset: 0n,
           },
         },
-        {
-          memcmp: {
-            bytes: authority as never,
-            encoding: 'base58',
-            offset: 8n,
-          },
-        },
+        ...extraFilters,
       ],
     })
     .send()) as any
@@ -353,6 +362,12 @@ export async function fetchTradePositions(
       if (left.data.id === right.data.id) return 0
       return left.data.id > right.data.id ? -1 : 1
     })
+}
+
+export async function fetchMarketTradePositions(
+  rpcClient: TwobRpcClient,
+): Promise<Array<TradePositionRecord>> {
+  return fetchTradePositionAccounts(rpcClient)
 }
 
 export async function fetchEndSlotBookkeepingSnapshot({

--- a/src/features/trading/components/order-book-table.tsx
+++ b/src/features/trading/components/order-book-table.tsx
@@ -1,0 +1,329 @@
+import { useMemo, useState } from 'react'
+import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink } from 'lucide-react'
+import {
+  formatAtoms,
+  formatExplorerAddressUrl,
+  shortenAddress,
+} from '../lib/format'
+import type { ReactNode } from 'react'
+import type { TradePositionRecord } from '../domain/models'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { endpoint } from '@/integrations/solana'
+import { cn } from '@/lib/utils'
+
+type OrderBookSortKey = 'direction' | 'endSlot' | 'flow' | 'size' | 'startSlot'
+
+type DirectionFilter = 'all' | 'buy' | 'sell'
+type SortDirection = 'asc' | 'desc'
+
+interface OrderBookRow {
+  amountAtoms: bigint
+  amountDecimals: number
+  amountToken: string
+  direction: 'Buy' | 'Sell'
+  endSlot: bigint
+  flowAtomsPerSlot: bigint
+  position: TradePositionRecord
+  startSlot: bigint
+}
+
+const ORDER_BOOK_COLUMNS = [
+  { label: 'Direction', sortKey: 'direction' },
+  { label: 'Position', sortKey: null },
+  { label: 'Size', sortKey: 'size' },
+  { label: 'Flow', sortKey: 'flow' },
+  { label: 'Start slot', sortKey: 'startSlot' },
+  { label: 'End slot', sortKey: 'endSlot' },
+] as const satisfies Array<{
+  label: string
+  sortKey: OrderBookSortKey | null
+}>
+
+const DIRECTION_FILTERS = [
+  { label: 'All', value: 'all' },
+  { label: 'Buy', value: 'buy' },
+  { label: 'Sell', value: 'sell' },
+] as const satisfies Array<{ label: string; value: DirectionFilter }>
+
+export function OrderBookTable({
+  baseDecimals,
+  baseTicker,
+  currentSlot,
+  isLoading,
+  positions,
+  quoteDecimals,
+  quoteTicker,
+}: {
+  baseDecimals: number
+  baseTicker: string
+  currentSlot: number | null
+  isLoading: boolean
+  positions: Array<TradePositionRecord>
+  quoteDecimals: number
+  quoteTicker: string
+}) {
+  const [directionFilter, setDirectionFilter] = useState<DirectionFilter>('all')
+  const [sort, setSort] = useState<{
+    direction: SortDirection
+    key: OrderBookSortKey
+  }>({ direction: 'asc', key: 'endSlot' })
+
+  const rows = useMemo(() => {
+    const activeRows = positions
+      .filter(
+        (position) =>
+          currentSlot === null ||
+          BigInt(Math.floor(currentSlot)) <= position.data.endSlot,
+      )
+      .map((position): OrderBookRow => {
+        const isBuy = position.data.isBuy === 1
+        const direction = isBuy ? 'Buy' : 'Sell'
+        const durationSlots = position.data.endSlot - position.data.startSlot
+        const normalizedDurationSlots = durationSlots > 0n ? durationSlots : 1n
+
+        return {
+          amountAtoms: position.data.amount,
+          amountDecimals: isBuy ? quoteDecimals : baseDecimals,
+          amountToken: isBuy ? quoteTicker : baseTicker,
+          direction,
+          endSlot: position.data.endSlot,
+          flowAtomsPerSlot: position.data.amount / normalizedDurationSlots,
+          position,
+          startSlot: position.data.startSlot,
+        }
+      })
+
+    const filteredRows = activeRows.filter((row) => {
+      if (directionFilter === 'all') return true
+      return directionFilter === 'buy'
+        ? row.direction === 'Buy'
+        : row.direction === 'Sell'
+    })
+
+    return filteredRows.sort((left, right) => {
+      const comparison = compareOrderBookRows(left, right, sort.key)
+      return sort.direction === 'asc' ? comparison : -comparison
+    })
+  }, [
+    baseDecimals,
+    baseTicker,
+    currentSlot,
+    directionFilter,
+    positions,
+    quoteDecimals,
+    quoteTicker,
+    sort.direction,
+    sort.key,
+  ])
+
+  const activeOrderCount = useMemo(
+    () =>
+      positions.filter(
+        (position) =>
+          currentSlot === null ||
+          BigInt(Math.floor(currentSlot)) <= position.data.endSlot,
+      ).length,
+    [currentSlot, positions],
+  )
+
+  const handleSort = (key: OrderBookSortKey) => {
+    setSort((current) =>
+      current.key === key
+        ? {
+            direction: current.direction === 'asc' ? 'desc' : 'asc',
+            key,
+          }
+        : { direction: key === 'endSlot' ? 'asc' : 'desc', key },
+    )
+  }
+
+  if (isLoading && rows.length === 0) {
+    return <OrderBookState>Loading active orders...</OrderBookState>
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="space-y-3">
+        <DirectionFilterControls
+          directionFilter={directionFilter}
+          onDirectionFilterChange={setDirectionFilter}
+        />
+        <OrderBookState>
+          {activeOrderCount === 0
+            ? 'No active orders are open for this market.'
+            : 'No active orders match the selected direction.'}
+        </OrderBookState>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <DirectionFilterControls
+        directionFilter={directionFilter}
+        onDirectionFilterChange={setDirectionFilter}
+      />
+      <div className="overflow-hidden rounded-[1.5rem] border border-white/8 bg-black/20">
+        <div className="max-h-[420px] overflow-auto">
+          <table className="w-full min-w-[720px] border-collapse text-left text-sm">
+            <thead className="sticky top-0 z-10 bg-[color:var(--color-page-bg)]/95 text-xs uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
+              <tr>
+                {ORDER_BOOK_COLUMNS.map((column) => (
+                  <th
+                    className="border-b border-white/8 px-4 py-3 font-medium"
+                    key={column.label}
+                  >
+                    {column.sortKey ? (
+                      <button
+                        className="flex items-center gap-1.5 whitespace-nowrap transition-colors hover:text-foreground"
+                        onClick={() => handleSort(column.sortKey)}
+                        type="button"
+                      >
+                        {column.label}
+                        <SortIcon
+                          active={sort.key === column.sortKey}
+                          direction={sort.direction}
+                        />
+                      </button>
+                    ) : (
+                      <span className="whitespace-nowrap">{column.label}</span>
+                    )}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr
+                  className="border-b border-white/6 last:border-0"
+                  key={row.position.address}
+                >
+                  <td className="px-4 py-3">
+                    <Badge
+                      variant={
+                        row.direction === 'Buy' ? 'positive' : 'negative'
+                      }
+                    >
+                      {row.direction}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3">
+                    <a
+                      className="inline-flex items-center gap-1.5 font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
+                      href={formatExplorerAddressUrl(
+                        row.position.address,
+                        endpoint,
+                      )}
+                      rel="noreferrer"
+                      target="_blank"
+                      title={row.position.address}
+                    >
+                      {shortenAddress(row.position.address, 6, 6)}
+                      <ExternalLink className="size-3" />
+                    </a>
+                  </td>
+                  <td className="px-4 py-3 font-medium">
+                    {formatAtoms(row.amountAtoms, row.amountDecimals)}{' '}
+                    {row.amountToken}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {formatAtoms(row.flowAtomsPerSlot, row.amountDecimals)}{' '}
+                    {row.amountToken}/slot
+                  </td>
+                  <td className="px-4 py-3 tabular-nums">
+                    {row.startSlot.toString()}
+                  </td>
+                  <td className="px-4 py-3 tabular-nums">
+                    {row.endSlot.toString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DirectionFilterControls({
+  directionFilter,
+  onDirectionFilterChange,
+}: {
+  directionFilter: DirectionFilter
+  onDirectionFilterChange: (value: DirectionFilter) => void
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {DIRECTION_FILTERS.map((filter) => (
+        <Button
+          aria-pressed={directionFilter === filter.value}
+          className="rounded-full"
+          key={filter.value}
+          onClick={() => onDirectionFilterChange(filter.value)}
+          size="xs"
+          variant={directionFilter === filter.value ? 'default' : 'outline'}
+        >
+          {filter.label}
+        </Button>
+      ))}
+    </div>
+  )
+}
+
+function compareOrderBookRows(
+  left: OrderBookRow,
+  right: OrderBookRow,
+  key: OrderBookSortKey,
+) {
+  switch (key) {
+    case 'direction':
+      return left.direction.localeCompare(right.direction)
+    case 'flow':
+      return compareBigint(left.flowAtomsPerSlot, right.flowAtomsPerSlot)
+    case 'size':
+      return compareBigint(left.amountAtoms, right.amountAtoms)
+    case 'startSlot':
+      return compareBigint(left.startSlot, right.startSlot)
+    case 'endSlot':
+      return compareBigint(left.endSlot, right.endSlot)
+  }
+}
+
+function compareBigint(left: bigint, right: bigint) {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
+function SortIcon({
+  active,
+  direction,
+}: {
+  active: boolean
+  direction: SortDirection
+}) {
+  const Icon = active
+    ? direction === 'asc'
+      ? ArrowUp
+      : ArrowDown
+    : ArrowUpDown
+
+  return (
+    <Icon
+      className={cn(
+        'size-3.5',
+        active ? 'text-foreground' : 'text-muted-foreground',
+      )}
+    />
+  )
+}
+
+function OrderBookState({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-[420px] items-center justify-center rounded-[1.5rem] border border-white/8 bg-white/5 px-6 text-center text-sm text-muted-foreground">
+      {children}
+    </div>
+  )
+}

--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   ChartCandlestick,
   ChartLine,
+  ListOrdered,
   RefreshCcw,
   X,
 } from 'lucide-react'
@@ -46,6 +47,7 @@ import { useMarketConfig } from '../hooks/use-market-config'
 import { useMarketPrice } from '../hooks/use-market-price'
 import { useMarketPriceChange24h } from '../hooks/use-market-price-change'
 import { useMarketUpdates } from '../hooks/use-market-updates'
+import { useMarketTradePositions } from '../hooks/use-market-trade-positions'
 import { useStreamingMarketState } from '../hooks/use-streaming-market-state'
 import { useTradePositions } from '../hooks/use-trade-positions'
 import { useClosedPositionEvents } from '../hooks/use-closed-position-events'
@@ -66,6 +68,7 @@ import {
 } from '../view-models/trading-dashboard'
 import { MarketPriceChart } from './market-price-chart'
 import { OrderEntryCard } from './order-entry-card'
+import { OrderBookTable } from './order-book-table'
 import { ActivePositionCard } from './active-position-card'
 import { ClosedPositionsList } from './closed-positions-list'
 import { HighPriceImpactDialog } from './high-price-impact-dialog'
@@ -78,7 +81,12 @@ import type {
   ChartHistoryRequest,
 } from './market-price-chart'
 import type { ChartPositionOverlay } from '../lib/chart-positions'
-import type { ChartTimeframe, OrderSide, PositionPanelTab } from '../constants'
+import type {
+  ChartTimeframe,
+  MarketPanelTab,
+  OrderSide,
+  PositionPanelTab,
+} from '../constants'
 import type { TradePositionRecord } from '../domain/models'
 import type { TradingViewAggregatedCandle } from '../lib/market'
 import { endpoint } from '@/integrations/solana'
@@ -105,6 +113,14 @@ const CHART_DISPLAY_MODES = [
   { icon: ChartCandlestick, label: 'Candles', mode: 'candles' },
   { icon: ChartLine, label: 'Line', mode: 'line' },
 ] as const
+const MARKET_PANEL_TABS = [
+  { icon: ChartCandlestick, label: 'Chart', tab: 'chart' },
+  { icon: ListOrdered, label: 'Order book', tab: 'order-book' },
+] as const satisfies Array<{
+  icon: typeof ChartCandlestick
+  label: string
+  tab: MarketPanelTab
+}>
 const CHART_POSITION_CLOSED_LOOKBACK_DAYS = 30
 const CHART_POSITION_CLOSED_LIMIT = 1000
 
@@ -125,6 +141,7 @@ export function TradingDashboard() {
   })
   const streamingStateQuery = useStreamingMarketState(marketAddress)
   const tradePositionsQuery = useTradePositions(address)
+  const orderBookPositionsQuery = useMarketTradePositions(marketAddress)
   const closedPositionChartLookbackStart = useMemo(
     () =>
       new Date(
@@ -144,6 +161,7 @@ export function TradingDashboard() {
   const [durationSeconds, setDurationSeconds] = useState(30 * 60)
   const [positionPanelTab, setPositionPanelTab] =
     useState<PositionPanelTab>('active')
+  const [marketPanelTab, setMarketPanelTab] = useState<MarketPanelTab>('chart')
   const [activePositionPage, setActivePositionPage] = useState(0)
   const [chartTimeframe, setChartTimeframe] = useState<ChartTimeframe>('5m')
   const [chartDisplayMode, setChartDisplayMode] =
@@ -247,6 +265,10 @@ export function TradingDashboard() {
     () => tradePositionsQuery.data ?? [],
     [tradePositionsQuery.data],
   )
+  const orderBookPositions = useMemo<Array<TradePositionRecord>>(
+    () => orderBookPositionsQuery.data ?? [],
+    [orderBookPositionsQuery.data],
+  )
   const closedChartPositions = useMemo(
     () => closedPositionChartQuery.data ?? [],
     [closedPositionChartQuery.data],
@@ -270,6 +292,7 @@ export function TradingDashboard() {
     [activePositions, normalizedActivePositionPage],
   )
   const currentSlot = streamingStateQuery.data?.currentSlot ?? null
+  const isOrderBookLoading = orderBookPositionsQuery.isLoading
   const chartPositionSlotRanges = useMemo(
     () =>
       buildChartPositionSlotRanges({
@@ -737,8 +760,12 @@ export function TradingDashboard() {
                 />
               }
             >
-              <ChartCandlestick className="size-4" />
-              Chart
+              {marketPanelTab === 'chart' ? (
+                <ChartCandlestick className="size-4" />
+              ) : (
+                <ListOrdered className="size-4" />
+              )}
+              {marketPanelTab === 'chart' ? 'Chart' : 'Orders'}
             </DrawerTrigger>
             <DrawerContent className="xl:hidden">
               <DrawerHeader>
@@ -755,35 +782,57 @@ export function TradingDashboard() {
                   </span>
                 </DrawerDescription>
               </DrawerHeader>
-              <PriceChartPanel
-                chartCandles={chartCandles}
-                chartDisplayMode={chartDisplayMode}
-                chartHeight={360}
-                chartTimeframe={chartTimeframe}
-                hasMoreHistory={marketChartHistory.hasMoreHistory}
-                isLoadingMoreHistory={marketChartHistory.isLoadingMoreHistory}
-                isMarketUpdatesLoading={marketUpdates.isLoading}
-                marketAddressError={
-                  marketAddressQuery.error instanceof Error
-                    ? marketAddressQuery.error.message
-                    : null
-                }
-                marketChartHistoryError={marketChartHistory.error}
-                marketUpdatesError={marketUpdates.error}
-                onCrosshairMove={setCrosshairData}
-                onDisplayModeChange={setChartDisplayMode}
-                onNeedOlderHistory={handleNeedOlderChartHistory}
-                onReset={() => setChartResetSignal((previous) => previous + 1)}
-                onTimeframeChange={setChartTimeframe}
-                positionOverlayError={
-                  closedPositionChartQuery.error instanceof Error
-                    ? closedPositionChartQuery.error.message
-                    : null
-                }
-                positionOverlays={chartPositionOverlays}
-                resetSignal={chartResetSignal}
-                statusMinHeightClassName="min-h-[360px]"
-              />
+              <div className="space-y-4">
+                <MarketPanelTabs
+                  activeTab={marketPanelTab}
+                  onTabChange={setMarketPanelTab}
+                />
+                {marketPanelTab === 'chart' ? (
+                  <PriceChartPanel
+                    chartCandles={chartCandles}
+                    chartDisplayMode={chartDisplayMode}
+                    chartHeight={360}
+                    chartTimeframe={chartTimeframe}
+                    hasMoreHistory={marketChartHistory.hasMoreHistory}
+                    isLoadingMoreHistory={
+                      marketChartHistory.isLoadingMoreHistory
+                    }
+                    isMarketUpdatesLoading={marketUpdates.isLoading}
+                    marketAddressError={
+                      marketAddressQuery.error instanceof Error
+                        ? marketAddressQuery.error.message
+                        : null
+                    }
+                    marketChartHistoryError={marketChartHistory.error}
+                    marketUpdatesError={marketUpdates.error}
+                    onCrosshairMove={setCrosshairData}
+                    onDisplayModeChange={setChartDisplayMode}
+                    onNeedOlderHistory={handleNeedOlderChartHistory}
+                    onReset={() =>
+                      setChartResetSignal((previous) => previous + 1)
+                    }
+                    onTimeframeChange={setChartTimeframe}
+                    positionOverlayError={
+                      closedPositionChartQuery.error instanceof Error
+                        ? closedPositionChartQuery.error.message
+                        : null
+                    }
+                    positionOverlays={chartPositionOverlays}
+                    resetSignal={chartResetSignal}
+                    statusMinHeightClassName="min-h-[360px]"
+                  />
+                ) : (
+                  <OrderBookTable
+                    baseDecimals={baseDecimals}
+                    baseTicker={baseTicker}
+                    currentSlot={currentSlot}
+                    isLoading={isOrderBookLoading}
+                    positions={orderBookPositions}
+                    quoteDecimals={quoteDecimals}
+                    quoteTicker={quoteTicker}
+                  />
+                )}
+              </div>
             </DrawerContent>
           </Drawer>
         </div>
@@ -837,36 +886,54 @@ export function TradingDashboard() {
 
           <div className="space-y-6 xl:col-start-1 xl:row-start-1">
             <Card className="hidden border-white/10 bg-black/15 xl:block">
-              <CardContent className="p-4">
-                <PriceChartPanel
-                  chartCandles={chartCandles}
-                  chartDisplayMode={chartDisplayMode}
-                  chartTimeframe={chartTimeframe}
-                  hasMoreHistory={marketChartHistory.hasMoreHistory}
-                  isLoadingMoreHistory={marketChartHistory.isLoadingMoreHistory}
-                  isMarketUpdatesLoading={marketUpdates.isLoading}
-                  marketAddressError={
-                    marketAddressQuery.error instanceof Error
-                      ? marketAddressQuery.error.message
-                      : null
-                  }
-                  marketChartHistoryError={marketChartHistory.error}
-                  marketUpdatesError={marketUpdates.error}
-                  onCrosshairMove={setCrosshairData}
-                  onDisplayModeChange={setChartDisplayMode}
-                  onNeedOlderHistory={handleNeedOlderChartHistory}
-                  onReset={() =>
-                    setChartResetSignal((previous) => previous + 1)
-                  }
-                  onTimeframeChange={setChartTimeframe}
-                  positionOverlayError={
-                    closedPositionChartQuery.error instanceof Error
-                      ? closedPositionChartQuery.error.message
-                      : null
-                  }
-                  positionOverlays={chartPositionOverlays}
-                  resetSignal={chartResetSignal}
+              <CardContent className="space-y-4 p-4">
+                <MarketPanelTabs
+                  activeTab={marketPanelTab}
+                  onTabChange={setMarketPanelTab}
                 />
+                {marketPanelTab === 'chart' ? (
+                  <PriceChartPanel
+                    chartCandles={chartCandles}
+                    chartDisplayMode={chartDisplayMode}
+                    chartTimeframe={chartTimeframe}
+                    hasMoreHistory={marketChartHistory.hasMoreHistory}
+                    isLoadingMoreHistory={
+                      marketChartHistory.isLoadingMoreHistory
+                    }
+                    isMarketUpdatesLoading={marketUpdates.isLoading}
+                    marketAddressError={
+                      marketAddressQuery.error instanceof Error
+                        ? marketAddressQuery.error.message
+                        : null
+                    }
+                    marketChartHistoryError={marketChartHistory.error}
+                    marketUpdatesError={marketUpdates.error}
+                    onCrosshairMove={setCrosshairData}
+                    onDisplayModeChange={setChartDisplayMode}
+                    onNeedOlderHistory={handleNeedOlderChartHistory}
+                    onReset={() =>
+                      setChartResetSignal((previous) => previous + 1)
+                    }
+                    onTimeframeChange={setChartTimeframe}
+                    positionOverlayError={
+                      closedPositionChartQuery.error instanceof Error
+                        ? closedPositionChartQuery.error.message
+                        : null
+                    }
+                    positionOverlays={chartPositionOverlays}
+                    resetSignal={chartResetSignal}
+                  />
+                ) : (
+                  <OrderBookTable
+                    baseDecimals={baseDecimals}
+                    baseTicker={baseTicker}
+                    currentSlot={currentSlot}
+                    isLoading={isOrderBookLoading}
+                    positions={orderBookPositions}
+                    quoteDecimals={quoteDecimals}
+                    quoteTicker={quoteTicker}
+                  />
+                )}
               </CardContent>
             </Card>
 
@@ -1044,6 +1111,32 @@ function PriceChangeBadge({
     <Badge className="normal-case tracking-normal" variant={variant}>
       {display}
     </Badge>
+  )
+}
+
+function MarketPanelTabs({
+  activeTab,
+  onTabChange,
+}: {
+  activeTab: MarketPanelTab
+  onTabChange: (tab: MarketPanelTab) => void
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {MARKET_PANEL_TABS.map(({ icon: Icon, label, tab }) => (
+        <Button
+          aria-pressed={activeTab === tab}
+          className="rounded-full"
+          key={tab}
+          onClick={() => onTabChange(tab)}
+          size="xs"
+          variant={activeTab === tab ? 'default' : 'outline'}
+        >
+          <Icon className="size-3.5" />
+          {label}
+        </Button>
+      ))}
+    </div>
   )
 }
 

--- a/src/features/trading/hooks/use-market-trade-positions.ts
+++ b/src/features/trading/hooks/use-market-trade-positions.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { useSolanaClient } from '@solana/react-hooks'
+import { tradingQueries } from '../queries'
+import type { Address } from '@solana/kit'
+
+export function useMarketTradePositions(marketAddress: Address | undefined) {
+  const client = useSolanaClient()
+
+  return useQuery({
+    ...tradingQueries.marketTradePositions({ client, marketAddress }),
+    enabled: Boolean(marketAddress),
+    refetchInterval: 5_000,
+  })
+}

--- a/src/features/trading/lib/format.ts
+++ b/src/features/trading/lib/format.ts
@@ -74,6 +74,22 @@ export function formatExplorerTransactionUrl(
   return `https://explorer.solana.com/tx/${encodeURIComponent(signature)}?cluster=${encodeURIComponent(cluster)}`
 }
 
+export function formatExplorerAddressUrl(address: string, endpoint: string) {
+  const cluster = endpoint.includes('mainnet')
+    ? 'mainnet-beta'
+    : endpoint.includes('testnet')
+      ? 'testnet'
+      : endpoint.includes('localhost') || endpoint.includes('127.0.0.1')
+        ? 'custom'
+        : 'devnet'
+
+  if (cluster === 'custom') {
+    return `https://explorer.solana.com/address/${encodeURIComponent(address)}?cluster=custom`
+  }
+
+  return `https://explorer.solana.com/address/${encodeURIComponent(address)}?cluster=${encodeURIComponent(cluster)}`
+}
+
 export function formatCrosshairTimeLabel(value: number | string | null) {
   if (value === null) return null
   const numeric = typeof value === 'number' ? value : Number(value)

--- a/src/features/trading/queries.ts
+++ b/src/features/trading/queries.ts
@@ -14,6 +14,7 @@ import {
 import {
   deriveMarketAddress,
   fetchEndSlotBookkeepingSnapshot,
+  fetchMarketTradePositions,
   fetchStreamingMarketState,
   fetchTradePositions,
   resolveSnapshotLocation,
@@ -107,6 +108,20 @@ export const tradingQueries = {
       queryFn: async () => {
         if (!authority) return []
         return fetchTradePositions(client.runtime.rpc, authority)
+      },
+    }),
+  marketTradePositions: ({
+    client,
+    marketAddress,
+  }: {
+    client: SolanaClient
+    marketAddress: Address | undefined
+  }) =>
+    queryOptions({
+      queryKey: tradingQueryKeys.marketTradePositions(marketAddress),
+      queryFn: async () => {
+        if (!marketAddress) return []
+        return fetchMarketTradePositions(client.runtime.rpc, marketAddress)
       },
     }),
   ownedPricesAccounts: ({

--- a/src/features/trading/query-keys.ts
+++ b/src/features/trading/query-keys.ts
@@ -29,6 +29,12 @@ export const tradingQueryKeys = {
     ['trading', 'market-price-change-24h', marketId] as const,
   tradePositions: (authority: string | null | undefined) =>
     ['trading', 'trade-positions', normalizeKeyPart(authority)] as const,
+  marketTradePositions: (marketAddress: string | null | undefined) =>
+    [
+      'trading',
+      'market-trade-positions',
+      normalizeKeyPart(marketAddress),
+    ] as const,
   ownedPricesAccounts: (authority: string | null | undefined) =>
     ['trading', 'owned-prices-accounts', normalizeKeyPart(authority)] as const,
   ownedExitsAccounts: (authority: string | null | undefined) =>


### PR DESCRIPTION
## Summary
- add a Chart / Order book switch to the trading market panel on desktop and mobile drawer
- fetch all live trade position accounts and filter out ended orders
- render a sortable active order table with size, flow, direction, and start/end slots
- show the position account as a non-sortable Explorer link
- add a direction filter for all, buy, or sell orders

## Notes
- current implementation assumes the app only has the SOL/USDC market, so active trade position accounts are treated as belonging to that market.
- submit transaction links were removed because fetching the latest signature would require one RPC request per active position and does not scale to thousands of rows. A future database/indexer-backed open positions table should store the submit signature if this column is needed.

## Verification
- pnpm exec eslint src/features/trading/components/order-book-table.tsx src/features/trading/lib/format.ts
- pnpm test
- pnpm build
- git diff --check