### PR TITLE
NAC-37: Fix mobile order book overflow

### DIFF
--- a/src/features/trading/components/order-book-table.tsx
+++ b/src/features/trading/components/order-book-table.tsx
@@ -144,7 +144,7 @@ export function OrderBookTable({
 
   if (rows.length === 0) {
     return (
-      <div className="space-y-3">
+      <div className="min-w-0 space-y-3">
         <DirectionFilterControls
           directionFilter={directionFilter}
           onDirectionFilterChange={setDirectionFilter}
@@ -159,13 +159,13 @@ export function OrderBookTable({
   }
 
   return (
-    <div className="space-y-3">
+    <div className="min-w-0 space-y-3">
       <DirectionFilterControls
         directionFilter={directionFilter}
         onDirectionFilterChange={setDirectionFilter}
       />
-      <div className="overflow-hidden rounded-[1.5rem] border border-white/8 bg-black/20">
-        <div className="max-h-[420px] overflow-auto">
+      <div className="max-w-full overflow-hidden rounded-[1.5rem] border border-white/8 bg-black/20">
+        <div className="max-h-[420px] w-full overflow-x-auto overflow-y-auto overscroll-contain">
           <table className="w-full min-w-[720px] border-collapse text-left text-sm">
             <thead className="sticky top-0 z-10 bg-[color:var(--color-page-bg)]/95 text-xs uppercase tracking-[0.18em] text-muted-foreground backdrop-blur">
               <tr>

--- a/src/features/trading/components/trading-dashboard.tsx
+++ b/src/features/trading/components/trading-dashboard.tsx
@@ -767,7 +767,7 @@ export function TradingDashboard() {
               )}
               {marketPanelTab === 'chart' ? 'Chart' : 'Orders'}
             </DrawerTrigger>
-            <DrawerContent className="xl:hidden">
+            <DrawerContent className="overflow-hidden xl:hidden">
               <DrawerHeader>
                 <DrawerTitle>
                   {baseTicker}/{quoteTicker}
@@ -782,7 +782,7 @@ export function TradingDashboard() {
                   </span>
                 </DrawerDescription>
               </DrawerHeader>
-              <div className="space-y-4">
+              <div className="min-w-0 space-y-4">
                 <MarketPanelTabs
                   activeTab={marketPanelTab}
                   onTabChange={setMarketPanelTab}


### PR DESCRIPTION
## Summary
- constrain the mobile drawer content so the order book cannot widen the viewport
- let the order book wrapper shrink inside grid layout with min-w-0
- keep the table horizontally scrollable inside its own container

## Verification
- pnpm exec eslint src/features/trading/components/order-book-table.tsx src/features/trading/components/trading-dashboard.tsx
- pnpm test
- pnpm build
- git diff --check

## Notes
- Attempted in-app browser verification at 390px width, but localhost navigation was blocked with ERR_BLOCKED_BY_CLIENT. The local dev server also requires Supabase env vars that are not present in this shell.